### PR TITLE
replace all misnamed occurrences of AGL to AHL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UAVs now support the new "sleep state" status code introduced in Skybrush
   Server 2.10.0.
 
+- Support for handling true AGL (_Above Ground Level_) data.
+
 ### Changed
 
 - The Electron based packaged version now uses a TCP socket to communicate
@@ -36,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed some cases in which the pending UAV Id overlay could remain on the
   screen without timing out.
+
+- Corrected the previously misnamed occurrences of AGL to AHL.
+  (_Above Ground Level_ -> _Above Home Level_)
 
 ## [2.6.0] - 2022-10-20
 

--- a/src/aframe/components/drone-flock.js
+++ b/src/aframe/components/drone-flock.js
@@ -26,7 +26,7 @@ const { THREE } = AFrame;
 /**
  * Selector that takes the Redux state and returns a function that can be called
  * with two arguments; the first argument must be an object having `lon`, `lat`
- * and `agl` properties, while the second argument must be an existing
+ * and `ahl` properties, while the second argument must be an existing
  * `THREE.Vector3` vector. This function will update the vector in-place to the
  * coordinates in the 3D view corresponding to the given GPS position.
  *
@@ -38,11 +38,11 @@ const getUpdatePositionFromGPSCoordinatesFunction = createSelector(
   getFlatEarthCoordinateTransformer,
   (transformation) => (coordinate, result) => {
     if (coordinate !== null && coordinate !== undefined && transformation) {
-      return transformation.updateVector3FromLonLatAgl(
+      return transformation.updateVector3FromLonLatAhl(
         result,
         coordinate.lon,
         coordinate.lat,
-        coordinate.agl
+        coordinate.ahl
       );
     }
   }

--- a/src/components/dialogs/FlyToTargetDialog.jsx
+++ b/src/components/dialogs/FlyToTargetDialog.jsx
@@ -29,7 +29,7 @@ import { CoordinateField, DistanceField, Select } from '../forms';
  */
 const initialValuePropType = PropTypes.shape({
   coords: PropTypes.string,
-  mode: PropTypes.oneOf(['relative', 'amsl', 'ahl']),
+  mode: PropTypes.oneOf(['relative', 'amsl', 'ahl', 'agl']),
   altitude: PropTypes.number,
 });
 
@@ -65,6 +65,7 @@ const FlyToTargetForm = ({
                 <MenuItem value='relative'>above current altitude</MenuItem>
                 <MenuItem value='amsl'>above mean sea level</MenuItem>
                 <MenuItem value='ahl'>above home level</MenuItem>
+                <MenuItem value='agl'>above ground level</MenuItem>
               </Select>
             </Box>
           </Box>

--- a/src/components/dialogs/FlyToTargetDialog.jsx
+++ b/src/components/dialogs/FlyToTargetDialog.jsx
@@ -29,7 +29,12 @@ import { CoordinateField, DistanceField, Select } from '../forms';
  */
 const initialValuePropType = PropTypes.shape({
   coords: PropTypes.string,
-  mode: PropTypes.oneOf(['relative', 'amsl', 'ahl', 'agl']),
+  mode: PropTypes.oneOf([
+    'relative',
+    'amsl',
+    'ahl',
+    // 'agl' // Not yet supported on the drones
+  ]),
   altitude: PropTypes.number,
 });
 
@@ -65,7 +70,8 @@ const FlyToTargetForm = ({
                 <MenuItem value='relative'>above current altitude</MenuItem>
                 <MenuItem value='amsl'>above mean sea level</MenuItem>
                 <MenuItem value='ahl'>above home level</MenuItem>
-                <MenuItem value='agl'>above ground level</MenuItem>
+                {/* 'agl' is not yet supported on the drones */}
+                {/* <MenuItem value='agl'>above ground level</MenuItem> */}
               </Select>
             </Box>
           </Box>

--- a/src/components/dialogs/FlyToTargetDialog.jsx
+++ b/src/components/dialogs/FlyToTargetDialog.jsx
@@ -29,7 +29,7 @@ import { CoordinateField, DistanceField, Select } from '../forms';
  */
 const initialValuePropType = PropTypes.shape({
   coords: PropTypes.string,
-  mode: PropTypes.oneOf(['relative', 'amsl', 'agl']),
+  mode: PropTypes.oneOf(['relative', 'amsl', 'ahl']),
   altitude: PropTypes.number,
 });
 
@@ -64,7 +64,7 @@ const FlyToTargetForm = ({
               <Select name='mode' label='Alt mode' margin='normal'>
                 <MenuItem value='relative'>above current altitude</MenuItem>
                 <MenuItem value='amsl'>above mean sea level</MenuItem>
-                <MenuItem value='agl'>above ground level</MenuItem>
+                <MenuItem value='ahl'>above home level</MenuItem>
               </Select>
             </Box>
           </Box>

--- a/src/features/measurement/MeasurementList.jsx
+++ b/src/features/measurement/MeasurementList.jsx
@@ -107,7 +107,7 @@ const useStyles = makeStyles(
       minWidth: 140,
     },
 
-    aglColumn: {
+    ahlColumn: {
       minWidth: 80,
       flex: 1,
     },
@@ -156,10 +156,10 @@ const MeasurementListItem = ({
           {'m '}
           <span className={classes.dim}>AMSL</span>
         </div>
-        <div className={classes.aglColumn}>
-          {formatMeanAndStdDev(mean.agl, sqDiff.agl, numSamples)}
+        <div className={classes.ahlColumn}>
+          {formatMeanAndStdDev(mean.ahl, sqDiff.ahl, numSamples)}
           {'m '}
-          <span className={classes.dim}>AGL</span>
+          <span className={classes.dim}>AHL</span>
         </div>
       </div>
     );
@@ -173,7 +173,7 @@ const MeasurementListItem = ({
         <div className={clsx(classes.dim, classes.amslColumn)}>
           {numSamples} samples
         </div>
-        <div className={clsx(classes.dim, classes.aglColumn)}>
+        <div className={clsx(classes.dim, classes.ahlColumn)}>
           Duration:{' '}
           {formatDurationOfSampling(startedAt, lastSampleAt, extraSamplingTime)}
         </div>

--- a/src/features/measurement/actions.js
+++ b/src/features/measurement/actions.js
@@ -82,7 +82,7 @@ export const stopAveragingSelectedUAVs = applyToSelection(
  */
 export const addNewSamplesToAveraging = (samples) => (dispatch, getState) => {
   const state = getState();
-  const keys = ['lat', 'lon', 'amsl', 'agl'];
+  const keys = ['lat', 'lon', 'amsl', 'ahl'];
   const updates = {};
 
   for (const [uavId, sample] of Object.entries(samples)) {

--- a/src/features/measurement/saga.js
+++ b/src/features/measurement/saga.js
@@ -33,7 +33,7 @@ export function* positionAveragingSaga() {
     for (const uavId of uavIds) {
       const item = payload[uavId];
       if (item) {
-        newSamples[uavId] = pick(item.position, ['lat', 'lon', 'amsl', 'agl']);
+        newSamples[uavId] = pick(item.position, ['lat', 'lon', 'amsl', 'ahl']);
       }
     }
 

--- a/src/features/measurement/slice.js
+++ b/src/features/measurement/slice.js
@@ -84,13 +84,13 @@ const { actions, reducer } = createSlice({
           lat: 0,
           lon: 0,
           amsl: 0,
-          agl: 0,
+          ahl: 0,
         },
         sqDiff: {
           lat: 0,
           lon: 0,
           amsl: 0,
-          agl: 0,
+          ahl: 0,
         },
       });
     },
@@ -127,13 +127,13 @@ const { actions, reducer } = createSlice({
               lat: 0,
               lon: 0,
               amsl: 0,
-              agl: 0,
+              ahl: 0,
             },
             sqDiff: {
               lat: 0,
               lon: 0,
               amsl: 0,
-              agl: 0,
+              ahl: 0,
             },
           };
         }

--- a/src/features/show/constants.js
+++ b/src/features/show/constants.js
@@ -7,7 +7,6 @@ export const COORDINATE_SYSTEM_TYPE = 'nwu';
  * Altitude reference types for drone shows.
  */
 export const ALTITUDE_REFERENCE = {
-  AGL: 'agl',
   AHL: 'ahl',
   AMSL: 'amsl',
 };

--- a/src/features/show/constants.js
+++ b/src/features/show/constants.js
@@ -7,7 +7,7 @@ export const COORDINATE_SYSTEM_TYPE = 'nwu';
  * Altitude reference types for drone shows.
  */
 export const ALTITUDE_REFERENCE = {
-  AGL: 'agl',
+  AHL: 'ahl',
   AMSL: 'amsl',
 };
 
@@ -15,7 +15,7 @@ export const ALTITUDE_REFERENCE = {
  * Default altitude reference object if it is not defined in the state yet.
  */
 export const DEFAULT_ALTITUDE_REFERENCE = {
-  type: ALTITUDE_REFERENCE.AGL,
+  type: ALTITUDE_REFERENCE.AHL,
   value: 0,
 };
 

--- a/src/features/show/constants.js
+++ b/src/features/show/constants.js
@@ -7,6 +7,7 @@ export const COORDINATE_SYSTEM_TYPE = 'nwu';
  * Altitude reference types for drone shows.
  */
 export const ALTITUDE_REFERENCE = {
+  AGL: 'agl',
   AHL: 'ahl',
   AMSL: 'amsl',
 };

--- a/src/features/show/selectors.js
+++ b/src/features/show/selectors.js
@@ -183,7 +183,7 @@ export const getOutdoorShowAltitudeReference = (state) => {
 /**
  * Selector that returns the mean sea level that the Z coordinates of the show
  * should be referred to, or null if the show is controlled based on altitudes
- * above ground level.
+ * above home level.
  */
 export const getMeanSeaLevelReferenceOfShowCoordinatesOrNull = (state) => {
   if (!isShowOutdoor(state)) {
@@ -206,7 +206,7 @@ export const getMeanSeaLevelReferenceOfShowCoordinatesOrNull = (state) => {
  * If this selector is true, it means that we can assign a fixed AMSL value to
  * each show-specific Z coordinate by adding the show-specific Z coordinate to
  * the AMSL reference. If this selector is false, it means that the show is
- * controlled in AGL. Indoor shows are always controlled in AGL.
+ * controlled in AHL. Indoor shows are always controlled in AHL.
  */
 export const isShowRelativeToMeanSeaLevel = (state) =>
   !isNil(getMeanSeaLevelReferenceOfShowCoordinatesOrNull(state));
@@ -325,7 +325,7 @@ export const getOutdoorShowToWorldCoordinateSystemTransformation =
 
             const [x, y, z] = point;
             const [lon, lat] = transform.toLonLat([x, y]);
-            return { lon, lat, amsl: undefined, agl: z };
+            return { lon, lat, amsl: undefined, ahl: z };
           }
         : undefined
   );
@@ -605,7 +605,7 @@ export const getShowDescription = createSelector(
   getShowDurationAsString,
   getMaximumHeightInTrajectories,
   (numberDrones, duration, maxHeight) =>
-    `${numberDrones} drones, ${duration}, max AGL ${maxHeight.toFixed(1)}m`
+    `${numberDrones} drones, ${duration}, max AHL ${maxHeight.toFixed(1)}m`
 );
 
 /**

--- a/src/features/show/selectors.js
+++ b/src/features/show/selectors.js
@@ -325,7 +325,7 @@ export const getOutdoorShowToWorldCoordinateSystemTransformation =
 
             const [x, y, z] = point;
             const [lon, lat] = transform.toLonLat([x, y]);
-            return { lon, lat, ahl: z };
+            return { lon, lat, amsl: undefined, ahl: z };
           }
         : undefined
   );

--- a/src/features/show/selectors.js
+++ b/src/features/show/selectors.js
@@ -325,7 +325,7 @@ export const getOutdoorShowToWorldCoordinateSystemTransformation =
 
             const [x, y, z] = point;
             const [lon, lat] = transform.toLonLat([x, y]);
-            return { lon, lat, amsl: undefined, ahl: z };
+            return { lon, lat, ahl: z };
           }
         : undefined
   );

--- a/src/features/three-d/selectors.js
+++ b/src/features/three-d/selectors.js
@@ -15,7 +15,7 @@ export const getCameraPose = (state) => state.threeD.camera;
 
 /**
  * Returns a function that can be called with a single object having `lon`,
- * `lat` and `agl` properties and that returns the corresponding coordinate
+ * `lat` and `ahl` properties and that returns the corresponding coordinate
  * in the coordinate system used by the 3D view.
  */
 const getGPSToThreeJSTransformation = createSelector(
@@ -27,10 +27,10 @@ const getGPSToThreeJSTransformation = createSelector(
         return null;
       }
 
-      const result = transformation.fromLonLatAgl([
+      const result = transformation.fromLonLatAhl([
         coordinate.lon,
         coordinate.lat,
-        coordinate.agl,
+        coordinate.ahl,
       ]);
 
       if (flipY) {

--- a/src/features/uav-control/actions.js
+++ b/src/features/uav-control/actions.js
@@ -18,7 +18,7 @@ const hasAMSL = (pos) =>
  * Thunk action factory that takes a geographical coordinate (without altitude)
  * and a list of selected UAV IDs, and opens the "Fly to target" dialog such
  * that the altitude in the dialog box is set to the mean AMSL of the selected
- * drones if more than one drone is selected, or to the AGL of the drone if a
+ * drones if more than one drone is selected, or to the AHL of the drone if a
  * single drone is selected.
  */
 export const openFlyToTargetDialogWithCoordinate =
@@ -37,11 +37,11 @@ export const openFlyToTargetDialogWithCoordinate =
     // altitude = NaN may happen if numberOfUAVs > 1 and the drones have no AMSLs
     const altitude =
       numberOfUAVsWithPositions === 1
-        ? positions[0].agl
+        ? positions[0].ahl
         : meanBy(positions.filter(hasAMSL), 'amsl');
     const finiteAltitude = Number.isFinite(altitude) ? altitude : 0;
     const mode =
-      numberOfUAVsWithPositions === 1 && finiteAltitude ? 'agl' : 'amsl';
+      numberOfUAVsWithPositions === 1 && finiteAltitude ? 'ahl' : 'amsl';
 
     const formatter = getPreferredCoordinateFormatter(state);
 
@@ -76,8 +76,8 @@ export const submitFlyToTargetDialog = (fields) => (dispatch, getState) => {
     };
 
     if (Number.isFinite(altitude)) {
-      if (fields.mode === 'agl') {
-        target.agl = altitude;
+      if (fields.mode === 'ahl') {
+        target.ahl = altitude;
       } else if (fields.mode === 'amsl') {
         target.amsl = altitude;
       } else if (fields.mode === 'relative' && Math.abs(altitude) > 0.01) {
@@ -93,10 +93,10 @@ export const submitFlyToTargetDialog = (fields) => (dispatch, getState) => {
             };
           }
 
-          if (currentPosition && currentPosition.agl) {
+          if (currentPosition && currentPosition.ahl) {
             return {
               ...baseTarget,
-              agl: currentPosition.agl + altitude,
+              ahl: currentPosition.ahl + altitude,
             };
           }
         };

--- a/src/features/uav-control/actions.js
+++ b/src/features/uav-control/actions.js
@@ -76,7 +76,9 @@ export const submitFlyToTargetDialog = (fields) => (dispatch, getState) => {
     };
 
     if (Number.isFinite(altitude)) {
-      if (fields.mode === 'ahl') {
+      if (fields.mode === 'agl') {
+        target.agl = altitude;
+      } else if (fields.mode === 'ahl') {
         target.ahl = altitude;
       } else if (fields.mode === 'amsl') {
         target.amsl = altitude;
@@ -97,6 +99,13 @@ export const submitFlyToTargetDialog = (fields) => (dispatch, getState) => {
             return {
               ...baseTarget,
               ahl: currentPosition.ahl + altitude,
+            };
+          }
+
+          if (currentPosition && currentPosition.agl) {
+            return {
+              ...baseTarget,
+              agl: currentPosition.agl + altitude,
             };
           }
         };

--- a/src/features/uav-control/slice.js
+++ b/src/features/uav-control/slice.js
@@ -34,7 +34,7 @@ const { actions, reducer } = createSlice({
       state.flyToTargetDialog.initialValues = {
         ...state.flyToTargetDialog.initialValues,
         coords,
-        mode: mode || 'agl',
+        mode: mode || 'ahl',
         altitude: isNil(altitude) ? 10 : altitude,
       };
 

--- a/src/features/uavs/AltitudeSummaryHeaderButton.jsx
+++ b/src/features/uavs/AltitudeSummaryHeaderButton.jsx
@@ -23,6 +23,22 @@ const buttonStyle = {
   width: 90,
 };
 
+const iconStyle = {
+  marginTop: -8,
+};
+
+const typeIndicatorStyle = {
+  marginTop: 4,
+
+  // TODO: Extract this color from the `secondaryLabel` style of
+  // `GenericHeaderButton` to be accessible through the theme's palette.
+  color: 'rgba(255, 255, 255, 0.54)',
+  fontSize: 10,
+  textAlign: 'center',
+  textTransform: 'uppercase',
+  userSelect: 'none',
+};
+
 const INITIAL_STATE = {
   min: null,
   max: null,
@@ -76,7 +92,8 @@ const AltitudeSummaryHeaderButton = ({
           onRequestTypeChange(getNextTypeForAltitudeSummaryType(type))
         }
       >
-        <Terrain />
+        <Terrain style={iconStyle} />
+        <div style={typeIndicatorStyle}>{type}</div>
         {isConnected && (
           <AltitudeSummaryUpdater type={type} onSetStatus={setSummary} />
         )}

--- a/src/features/uavs/AltitudeSummaryHeaderButton.jsx
+++ b/src/features/uavs/AltitudeSummaryHeaderButton.jsx
@@ -17,25 +17,29 @@ import {
 
 import AltitudeSummaryUpdater from './AltitudeSummaryUpdater';
 
+// `makeStyles` from @material-ui cannot be used, as `GenericHeaderButton`
+// doesn't merge its own classes with the provided `className` from outside.
 const buttonStyle = {
   justifyContent: 'space-between',
   textAlign: 'right',
-  width: 90,
+  width: 95,
 };
 
-const iconStyle = {
-  marginTop: -8,
+const iconContainerStyle = {
+  width: 24,
+  marginTop: -10,
+
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: 4,
 };
 
 const typeIndicatorStyle = {
-  marginTop: 4,
-
-  // TODO: Extract this color from the `secondaryLabel` style of
-  // `GenericHeaderButton` to be accessible through the theme's palette.
-  color: 'rgba(255, 255, 255, 0.54)',
-  fontSize: 10,
-  textAlign: 'center',
+  fontSize: 11,
+  fontWeight: 'bold',
   textTransform: 'uppercase',
+  textAlign: 'center',
   userSelect: 'none',
 };
 
@@ -82,18 +86,25 @@ const AltitudeSummaryHeaderButton = ({
       <GenericHeaderButton
         disabled={!isConnected}
         label={
-          isConnected && typeof max === 'number' ? `${max.toFixed(1)}m` : '—'
+          isConnected && typeof max === 'number'
+            ? `${max.toFixed(1)}\u00A0m`
+            : '—'
         }
         secondaryLabel={
-          isConnected && typeof min === 'number' ? `${min.toFixed(1)}m` : '—'
+          isConnected && typeof min === 'number'
+            ? `${min.toFixed(1)}\u00A0m`
+            : '—'
         }
         style={buttonStyle}
         onClick={() =>
           onRequestTypeChange(getNextTypeForAltitudeSummaryType(type))
         }
       >
-        <Terrain style={iconStyle} />
-        <div style={typeIndicatorStyle}>{type}</div>
+        <div style={iconContainerStyle}>
+          <Terrain />
+          <div style={typeIndicatorStyle}>{type}</div>
+        </div>
+
         {isConnected && (
           <AltitudeSummaryUpdater type={type} onSetStatus={setSummary} />
         )}

--- a/src/features/uavs/AltitudeSummaryHeaderButton.jsx
+++ b/src/features/uavs/AltitudeSummaryHeaderButton.jsx
@@ -33,6 +33,8 @@ const getNextTypeForAltitudeSummaryType = (type) => {
     case AltitudeSummaryType.AMSL:
       return AltitudeSummaryType.AHL;
     case AltitudeSummaryType.AHL:
+      return AltitudeSummaryType.AGL;
+    case AltitudeSummaryType.AGL:
       return AltitudeSummaryType.XYZ;
     case AltitudeSummaryType.XYZ:
       return AltitudeSummaryType.AMSL;

--- a/src/features/uavs/AltitudeSummaryHeaderButton.jsx
+++ b/src/features/uavs/AltitudeSummaryHeaderButton.jsx
@@ -31,8 +31,8 @@ const INITIAL_STATE = {
 const getNextTypeForAltitudeSummaryType = (type) => {
   switch (type) {
     case AltitudeSummaryType.AMSL:
-      return AltitudeSummaryType.AGL;
-    case AltitudeSummaryType.AGL:
+      return AltitudeSummaryType.AHL;
+    case AltitudeSummaryType.AHL:
       return AltitudeSummaryType.XYZ;
     case AltitudeSummaryType.XYZ:
       return AltitudeSummaryType.AMSL;

--- a/src/features/uavs/AltitudeSummaryUpdater.jsx
+++ b/src/features/uavs/AltitudeSummaryUpdater.jsx
@@ -10,12 +10,12 @@ import { getActiveUAVIds, getUAVById } from './selectors';
 
 /**
  * Mapping from altitude summary types to functions that take a UAV object and
- * return an altitude according to the selected summary type (AMSL, AGL or local).
+ * return an altitude according to the selected summary type (AMSL, AHL or local).
  */
 const altitudeGetters = {
   /* eslint-disable object-shorthand */
   [AltitudeSummaryType.AMSL]: (uav) => uav?.position?.amsl,
-  [AltitudeSummaryType.AGL]: (uav) => uav?.position?.agl,
+  [AltitudeSummaryType.AHL]: (uav) => uav?.position?.ahl,
 
   [AltitudeSummaryType.XYZ]: (uav) => {
     const pos = uav?.localPosition;

--- a/src/features/uavs/AltitudeSummaryUpdater.jsx
+++ b/src/features/uavs/AltitudeSummaryUpdater.jsx
@@ -10,12 +10,14 @@ import { getActiveUAVIds, getUAVById } from './selectors';
 
 /**
  * Mapping from altitude summary types to functions that take a UAV object and
- * return an altitude according to the selected summary type (AMSL, AHL or local).
+ * return an altitude according to the selected summary type.
+ * (AMSL, AHL, AGL or local)
  */
 const altitudeGetters = {
   /* eslint-disable object-shorthand */
   [AltitudeSummaryType.AMSL]: (uav) => uav?.position?.amsl,
   [AltitudeSummaryType.AHL]: (uav) => uav?.position?.ahl,
+  [AltitudeSummaryType.AGL]: (uav) => uav?.position?.agl,
 
   [AltitudeSummaryType.XYZ]: (uav) => {
     const pos = uav?.localPosition;

--- a/src/features/uavs/DroneInfoTooltipContent.jsx
+++ b/src/features/uavs/DroneInfoTooltipContent.jsx
@@ -143,8 +143,8 @@ const DroneInfoTooltipContent = ({
         ) : (
           <>
             <div className={classes.altitudeLabel}>
-              {formatNumberSafely(position?.agl, 1, ' m', naText)}
-              <span className='muted'>{'\u00A0'}AGL</span>
+              {formatNumberSafely(position?.ahl, 1, ' m', naText)}
+              <span className='muted'>{'\u00A0'}AHL</span>
             </div>
             <div className={classes.numSatellitesLabel}>
               {formatNumberSafely(numSatellites, 0, '', naText)}
@@ -175,7 +175,7 @@ DroneInfoTooltipContent.propTypes = {
   localPosition: PropTypes.arrayOf(PropTypes.number),
   mode: PropTypes.string,
   position: PropTypes.shape({
-    agl: PropTypes.number,
+    ahl: PropTypes.number,
   }),
   text: PropTypes.string,
   textSemantics: PropTypes.string,

--- a/src/features/uavs/StatusSummaryMiniTable.js
+++ b/src/features/uavs/StatusSummaryMiniTable.js
@@ -57,7 +57,7 @@ const StatusSummaryMiniTable = ({
   position,
 }) => {
   const classes = useStyles();
-  const { lat, lon, amsl, ahl } = position || {};
+  const { lat, lon, amsl, ahl, agl } = position || {};
   const hasLocalPosition = localPosition && Array.isArray(localPosition);
   const flightModeLabel = mode ? (
     <StatusText status={getSemanticsForFlightMode(mode)}>
@@ -87,6 +87,7 @@ const StatusSummaryMiniTable = ({
       ['Lon', formatNumberSafely(lon, 7, '°', naText)],
       ['AMSL', formatNumberSafely(amsl, 2, ' m', naText)],
       ['AHL', formatNumberSafely(ahl, 2, ' m', naText)],
+      ['AGL', formatNumberSafely(agl, 2, ' m', naText)],
       'sep2'
     );
   }
@@ -142,6 +143,7 @@ StatusSummaryMiniTable.propTypes = {
     lon: PropTypes.number,
     amsl: PropTypes.number,
     ahl: PropTypes.number,
+    agl: PropTypes.number,
   }),
 };
 

--- a/src/features/uavs/StatusSummaryMiniTable.js
+++ b/src/features/uavs/StatusSummaryMiniTable.js
@@ -57,7 +57,7 @@ const StatusSummaryMiniTable = ({
   position,
 }) => {
   const classes = useStyles();
-  const { lat, lon, amsl, agl } = position || {};
+  const { lat, lon, amsl, ahl } = position || {};
   const hasLocalPosition = localPosition && Array.isArray(localPosition);
   const flightModeLabel = mode ? (
     <StatusText status={getSemanticsForFlightMode(mode)}>
@@ -86,7 +86,7 @@ const StatusSummaryMiniTable = ({
       ['Lat', formatNumberSafely(lat, 7, '°', naText)],
       ['Lon', formatNumberSafely(lon, 7, '°', naText)],
       ['AMSL', formatNumberSafely(amsl, 2, ' m', naText)],
-      ['AGL', formatNumberSafely(agl, 2, ' m', naText)],
+      ['AHL', formatNumberSafely(ahl, 2, ' m', naText)],
       'sep2'
     );
   }
@@ -141,7 +141,7 @@ StatusSummaryMiniTable.propTypes = {
     lat: PropTypes.number,
     lon: PropTypes.number,
     amsl: PropTypes.number,
-    agl: PropTypes.number,
+    ahl: PropTypes.number,
   }),
 };
 

--- a/src/features/uavs/selectors.js
+++ b/src/features/uavs/selectors.js
@@ -709,10 +709,10 @@ export function getSingleUAVStatusSummary(uav) {
     } else {
       textSemantics = errorSeverityToSemantics(severity);
     }
-  } else if (uav.position && Math.abs(uav.position.agl) >= 0.3) {
+  } else if (uav.position && Math.abs(uav.position.ahl) >= 0.3) {
     // UAV is in the air
     text = 'airborne';
-    details = `${uav.position.agl.toFixed(2)}m`;
+    details = `${uav.position.ahl.toFixed(2)}m`;
     textSemantics = 'success';
   } else {
     // UAV is ready on the ground

--- a/src/features/uavs/slice.js
+++ b/src/features/uavs/slice.js
@@ -27,7 +27,7 @@ const { actions, reducer } = createSlice({
       //     id: "01",
       //     lastUpdated: 1580225775722,
       //     position: {
-      //         lat: 47.4732476, lon: 19.0618718, amsl: undefined, agl: 0
+      //         lat: 47.4732476, lon: 19.0618718, amsl: undefined, ahl: 0
       //     },
       //     gpsFix: ['3D', 17],
       //     heading: 210,

--- a/src/features/uavs/slice.js
+++ b/src/features/uavs/slice.js
@@ -27,7 +27,11 @@ const { actions, reducer } = createSlice({
       //     id: "01",
       //     lastUpdated: 1580225775722,
       //     position: {
-      //         lat: 47.4732476, lon: 19.0618718, amsl: undefined, ahl: 0
+      //         lat: 47.4732476,
+      //         lon: 19.0618718,
+      //         amsl: undefined,
+      //         ahl: 0,
+      //         agl: undefined,
       //     },
       //     gpsFix: ['3D', 17],
       //     heading: 210,

--- a/src/model/beacons.js
+++ b/src/model/beacons.js
@@ -14,6 +14,7 @@ export const mapPosition = (positionFromServer) =>
         lon: positionFromServer[1] / 1e7,
         amsl: isNil(positionFromServer[2]) ? null : positionFromServer[2] / 1e3,
         ahl: isNil(positionFromServer[3]) ? null : positionFromServer[3] / 1e3,
+        agl: isNil(positionFromServer[4]) ? null : positionFromServer[4] / 1e3,
       }
     : null;
 

--- a/src/model/beacons.js
+++ b/src/model/beacons.js
@@ -13,7 +13,7 @@ export const mapPosition = (positionFromServer) =>
         lat: positionFromServer[0] / 1e7,
         lon: positionFromServer[1] / 1e7,
         amsl: isNil(positionFromServer[2]) ? null : positionFromServer[2] / 1e3,
-        agl: isNil(positionFromServer[3]) ? null : positionFromServer[3] / 1e3,
+        ahl: isNil(positionFromServer[3]) ? null : positionFromServer[3] / 1e3,
       }
     : null;
 

--- a/src/model/settings.js
+++ b/src/model/settings.js
@@ -4,19 +4,19 @@
 
 export const AltitudeSummaryType = {
   AMSL: 'amsl',
-  AGL: 'agl',
+  AHL: 'ahl',
   XYZ: 'xyz',
 };
 
 const _altitudeSummaryTypeDescriptions = {
   [AltitudeSummaryType.AMSL]: 'Altitude above mean sea level',
-  [AltitudeSummaryType.AGL]: 'Altitude above ground level',
+  [AltitudeSummaryType.AHL]: 'Altitude above home level',
   [AltitudeSummaryType.XYZ]: 'Altitude in local coordinate system',
 };
 
 const _altitudeSummaryTypeShortDescriptions = {
   [AltitudeSummaryType.AMSL]: 'AMSL',
-  [AltitudeSummaryType.AGL]: 'AGL',
+  [AltitudeSummaryType.AHL]: 'AHL',
   [AltitudeSummaryType.XYZ]: 'Z coordinate',
 };
 

--- a/src/model/settings.js
+++ b/src/model/settings.js
@@ -5,18 +5,21 @@
 export const AltitudeSummaryType = {
   AMSL: 'amsl',
   AHL: 'ahl',
+  AGL: 'agl',
   XYZ: 'xyz',
 };
 
 const _altitudeSummaryTypeDescriptions = {
   [AltitudeSummaryType.AMSL]: 'Altitude above mean sea level',
   [AltitudeSummaryType.AHL]: 'Altitude above home level',
+  [AltitudeSummaryType.AGL]: 'Altitude above ground level',
   [AltitudeSummaryType.XYZ]: 'Altitude in local coordinate system',
 };
 
 const _altitudeSummaryTypeShortDescriptions = {
   [AltitudeSummaryType.AMSL]: 'AMSL',
   [AltitudeSummaryType.AHL]: 'AHL',
+  [AltitudeSummaryType.AGL]: 'AGL',
   [AltitudeSummaryType.XYZ]: 'Z coordinate',
 };
 

--- a/src/model/sorting.js
+++ b/src/model/sorting.js
@@ -16,6 +16,7 @@ export const UAVSortKey = Object.freeze({
   GPS_FIX: 'gpsFix',
   ALTITUDE_MSL: 'amsl',
   ALTITUDE_HOME: 'ahl',
+  ALTITUDE_GROUND: 'agl',
   HEADING: 'heading',
 });
 
@@ -30,6 +31,7 @@ export const UAVSortKeys = [
   UAVSortKey.GPS_FIX,
   UAVSortKey.ALTITUDE_MSL,
   UAVSortKey.ALTITUDE_HOME,
+  UAVSortKey.ALTITUDE_GROUND,
   UAVSortKey.HEADING,
 ];
 
@@ -44,6 +46,7 @@ export const labelsForUAVSortKey = {
   [UAVSortKey.GPS_FIX]: 'GPS fix',
   [UAVSortKey.ALTITUDE_MSL]: 'Altitude (MSL)',
   [UAVSortKey.ALTITUDE_HOME]: 'Altitude above home',
+  [UAVSortKey.ALTITUDE_GROUND]: 'Altitude above ground',
   [UAVSortKey.HEADING]: 'Heading',
 };
 
@@ -58,6 +61,7 @@ export const shortLabelsForUAVSortKey = {
   [UAVSortKey.GPS_FIX]: 'GPS fix',
   [UAVSortKey.ALTITUDE_MSL]: 'AMSL',
   [UAVSortKey.ALTITUDE_HOME]: 'AHL',
+  [UAVSortKey.ALTITUDE_GROUND]: 'AGL',
   [UAVSortKey.HEADING]: 'Heading',
 };
 
@@ -130,6 +134,14 @@ export const getKeyFunctionForUAVSortKey = memoize((key) => {
       // TODO(ntamas): fall back to Z coordinate if no AHL is given
       return (uav) => {
         const result = uav?.position?.ahl;
+        return isNil(result) ? -10000 : result;
+      };
+
+    case UAVSortKey.ALTITUDE_GROUND:
+      // Sort UAVs based on altitude above ground
+      // TODO(ntamas): fall back to Z coordinate if no AGL is given
+      return (uav) => {
+        const result = uav?.position?.agl;
         return isNil(result) ? -10000 : result;
       };
 

--- a/src/model/sorting.js
+++ b/src/model/sorting.js
@@ -15,7 +15,7 @@ export const UAVSortKey = Object.freeze({
   BATTERY: 'battery',
   GPS_FIX: 'gpsFix',
   ALTITUDE_MSL: 'amsl',
-  ALTITUDE_GROUND: 'agl',
+  ALTITUDE_HOME: 'ahl',
   HEADING: 'heading',
 });
 
@@ -29,7 +29,7 @@ export const UAVSortKeys = [
   UAVSortKey.BATTERY,
   UAVSortKey.GPS_FIX,
   UAVSortKey.ALTITUDE_MSL,
-  UAVSortKey.ALTITUDE_GROUND,
+  UAVSortKey.ALTITUDE_HOME,
   UAVSortKey.HEADING,
 ];
 
@@ -43,7 +43,7 @@ export const labelsForUAVSortKey = {
   [UAVSortKey.BATTERY]: 'Battery',
   [UAVSortKey.GPS_FIX]: 'GPS fix',
   [UAVSortKey.ALTITUDE_MSL]: 'Altitude (MSL)',
-  [UAVSortKey.ALTITUDE_GROUND]: 'Altitude above ground',
+  [UAVSortKey.ALTITUDE_HOME]: 'Altitude above home',
   [UAVSortKey.HEADING]: 'Heading',
 };
 
@@ -57,7 +57,7 @@ export const shortLabelsForUAVSortKey = {
   [UAVSortKey.BATTERY]: 'Battery',
   [UAVSortKey.GPS_FIX]: 'GPS fix',
   [UAVSortKey.ALTITUDE_MSL]: 'AMSL',
-  [UAVSortKey.ALTITUDE_GROUND]: 'AGL',
+  [UAVSortKey.ALTITUDE_HOME]: 'AHL',
   [UAVSortKey.HEADING]: 'Heading',
 };
 
@@ -125,11 +125,11 @@ export const getKeyFunctionForUAVSortKey = memoize((key) => {
         return isNil(result) ? -10000 : result;
       };
 
-    case UAVSortKey.ALTITUDE_GROUND:
-      // Sort UAVs based on altitude above ground
-      // TODO(ntamas): fall back to Z coordinate if no AGL is given
+    case UAVSortKey.ALTITUDE_HOME:
+      // Sort UAVs based on altitude above home
+      // TODO(ntamas): fall back to Z coordinate if no AHL is given
       return (uav) => {
-        const result = uav?.position?.agl;
+        const result = uav?.position?.ahl;
         return isNil(result) ? -10000 : result;
       };
 

--- a/src/model/uav.js
+++ b/src/model/uav.js
@@ -44,7 +44,7 @@ export default class UAV {
       lat: undefined,
       lon: undefined,
       amsl: undefined,
-      agl: undefined,
+      ahl: undefined,
     };
     this._rawHeading = undefined;
     this._rawVoltage = undefined;
@@ -65,10 +65,10 @@ export default class UAV {
   }
 
   /**
-   * Returns the altitude above ground level, if known.
+   * Returns the altitude above home level, if known.
    */
-  get agl() {
-    return this._position.agl;
+  get ahl() {
+    return this._position.ahl;
   }
 
   /**
@@ -204,7 +204,7 @@ export default class UAV {
       }
 
       if (!isNil(position[3])) {
-        this._position.agl = position[3] / 1e3;
+        this._position.ahl = position[3] / 1e3;
       }
 
       updated = true;

--- a/src/model/uav.js
+++ b/src/model/uav.js
@@ -45,6 +45,7 @@ export default class UAV {
       lon: undefined,
       amsl: undefined,
       ahl: undefined,
+      agl: undefined,
     };
     this._rawHeading = undefined;
     this._rawVoltage = undefined;
@@ -62,6 +63,13 @@ export default class UAV {
     this.light = 0xffff; /* white in RGB565 */
     this.localPosition = [undefined, undefined, undefined];
     this.mode = undefined;
+  }
+
+  /**
+   * Returns the altitude above ground level, if known.
+   */
+  get agl() {
+    return this._position.agl;
   }
 
   /**
@@ -199,12 +207,17 @@ export default class UAV {
     if (position) {
       this._position.lat = position[0] / 1e7;
       this._position.lon = position[1] / 1e7;
+
       if (!isNil(position[2])) {
         this._position.amsl = position[2] / 1e3;
       }
 
       if (!isNil(position[3])) {
         this._position.ahl = position[3] / 1e3;
+      }
+
+      if (!isNil(position[4])) {
+        this._position.agl = position[4] / 1e3;
       }
 
       updated = true;

--- a/src/utils/geography.js
+++ b/src/utils/geography.js
@@ -556,12 +556,12 @@ export class FlatEarthCoordinateSystem {
   }
 
   /**
-   * Converts a longitude-latitude-AGL triplet to flat Earth coordinates.
+   * Converts a longitude-latitude-AHL triplet to flat Earth coordinates.
    *
-   * @param {number[]} coords  a longitude-latitude-AGL triplet to convert
+   * @param {number[]} coords  a longitude-latitude-AHL triplet to convert
    * @return {number[]} the converted coordinates
    */
-  fromLonLatAgl(coords) {
+  fromLonLatAhl(coords) {
     const result = [0, 0, coords[2]];
     return this._updateArrayFromLonLat(result, coords[0], coords[1]);
   }
@@ -590,20 +590,20 @@ export class FlatEarthCoordinateSystem {
   }
 
   /**
-   * Converts a flat Earth coordinate triplet to a longitude-latitude-AGL
+   * Converts a flat Earth coordinate triplet to a longitude-latitude-AHL
    * triplet.
    *
-   * The Z coordinate of the triplet is copied straight to the AGL value.
+   * The Z coordinate of the triplet is copied straight to the AHL value.
    *
    * @param {number[]} coords  a flat Earth coordinate triplet to convert
    * @return {number[]} the converted coordinates
    */
-  toLonLatAgl(coords) {
+  toLonLatAhl(coords) {
     return [...this.toLonLat(coords), coords[2]];
   }
 
   /**
-   * Updates a THREE.Vector3 object from a longitude-latitude-AGL triplet.
+   * Updates a THREE.Vector3 object from a longitude-latitude-AHL triplet.
    *
    * This function is designed in a way that it avoids object allocations at
    * all costs.
@@ -614,14 +614,14 @@ export class FlatEarthCoordinateSystem {
    * @param {THREE.Vector3}  vec  the vector to update
    * @param {number}  lon  the longitude
    * @param {number}  lat  the latitude
-   * @param {number}  agl  the altitude above ground level
+   * @param {number}  ahl  the altitude above home level
    */
-  updateVector3FromLonLatAgl(vec, lon, lat, agl) {
+  updateVector3FromLonLatAhl(vec, lon, lat, ahl) {
     this._updateArrayFromLonLat(this._vec, lon, lat);
 
     vec.x = this._vec[0];
     vec.y = this._type === 'nwu' ? this._vec[1] : -this._vec[1];
-    vec.z = agl;
+    vec.z = ahl;
   }
 
   /**

--- a/src/utils/messaging.js
+++ b/src/utils/messaging.js
@@ -158,6 +158,7 @@ const moveUAVsLowLevel = performMassOperation({
       Math.round(target.lon * 1e7),
       isNil(target.amsl) ? null : Math.round(target.amsl * 1e3),
       isNil(target.ahl) ? null : Math.round(target.ahl * 1e3),
+      isNil(target.agl) ? null : Math.round(target.agl * 1e3),
     ],
   }),
 });
@@ -167,10 +168,10 @@ export const moveUAVs = (uavIds, { target, ...rest }) => {
     throw new Error('No target given in arguments');
   }
 
-  const { lat, lon, amsl, ahl } = target;
+  const { lat, lon, amsl, ahl, agl } = target;
 
-  if (!isNil(amsl) && !isNil(ahl)) {
-    throw new Error('only one of AMSL and AHL may be given');
+  if (!isNil(amsl) && !isNil(ahl) && !isNil(agl)) {
+    throw new Error('only one of AMSL, AHL and AGL may be given');
   }
 
   const args = rest;
@@ -179,6 +180,8 @@ export const moveUAVs = (uavIds, { target, ...rest }) => {
     args.target = { lat, lon, amsl };
   } else if (!isNil(ahl)) {
     args.target = { lat, lon, ahl };
+  } else if (!isNil(agl)) {
+    args.target = { lat, lon, agl };
   } else {
     args.target = { lat, lon };
   }

--- a/src/utils/messaging.js
+++ b/src/utils/messaging.js
@@ -157,7 +157,7 @@ const moveUAVsLowLevel = performMassOperation({
       Math.round(target.lat * 1e7),
       Math.round(target.lon * 1e7),
       isNil(target.amsl) ? null : Math.round(target.amsl * 1e3),
-      isNil(target.agl) ? null : Math.round(target.agl * 1e3),
+      isNil(target.ahl) ? null : Math.round(target.ahl * 1e3),
     ],
   }),
 });
@@ -167,18 +167,18 @@ export const moveUAVs = (uavIds, { target, ...rest }) => {
     throw new Error('No target given in arguments');
   }
 
-  const { lat, lon, amsl, agl } = target;
+  const { lat, lon, amsl, ahl } = target;
 
-  if (!isNil(amsl) && !isNil(agl)) {
-    throw new Error('only one of AMSL and AGL may be given');
+  if (!isNil(amsl) && !isNil(ahl)) {
+    throw new Error('only one of AMSL and AHL may be given');
   }
 
   const args = rest;
 
   if (!isNil(amsl)) {
     args.target = { lat, lon, amsl };
-  } else if (!isNil(agl)) {
-    args.target = { lat, lon, agl };
+  } else if (!isNil(ahl)) {
+    args.target = { lat, lon, ahl };
   } else {
     args.target = { lat, lon };
   }

--- a/src/views/map/MapContextMenu.jsx
+++ b/src/views/map/MapContextMenu.jsx
@@ -337,7 +337,7 @@ class MapContextMenu extends React.Component {
   _moveSelectedUAVsAtGivenAltitude = async (_event, context) => {
     const coords = [...context.coords];
     const selectedUAVIds = [...context.selectedUAVIds];
-    /* TODO(ntamas): use AGL of selected UAVs */
+    /* TODO(ntamas): use AHL of selected UAVs */
     this.props.showFlyToTargetDialog({ coords, uavIds: selectedUAVIds });
   };
 

--- a/src/views/show-control/EnvironmentButton.jsx
+++ b/src/views/show-control/EnvironmentButton.jsx
@@ -39,9 +39,6 @@ const getEnvironmentDescription = createSelector(
         } else if (type === ALTITUDE_REFERENCE.AHL) {
           // value should be ignored in this case
           return `Outdoor, relative to home`;
-        } else if (type === ALTITUDE_REFERENCE.AGL) {
-          // value should be ignored in this case
-          return `Outdoor, relative to ground`;
         } else {
           return 'Outdoor, unknown altitude reference';
         }

--- a/src/views/show-control/EnvironmentButton.jsx
+++ b/src/views/show-control/EnvironmentButton.jsx
@@ -39,6 +39,9 @@ const getEnvironmentDescription = createSelector(
         } else if (type === ALTITUDE_REFERENCE.AHL) {
           // value should be ignored in this case
           return `Outdoor, relative to home`;
+        } else if (type === ALTITUDE_REFERENCE.AGL) {
+          // value should be ignored in this case
+          return `Outdoor, relative to ground`;
         } else {
           return 'Outdoor, unknown altitude reference';
         }

--- a/src/views/show-control/EnvironmentButton.jsx
+++ b/src/views/show-control/EnvironmentButton.jsx
@@ -36,9 +36,9 @@ const getEnvironmentDescription = createSelector(
           } else {
             return 'Outdoor, invalid altitude reference';
           }
-        } else if (type === ALTITUDE_REFERENCE.AGL) {
+        } else if (type === ALTITUDE_REFERENCE.AHL) {
           // value should be ignored in this case
-          return `Outdoor, relative to ground`;
+          return `Outdoor, relative to home`;
         } else {
           return 'Outdoor, unknown altitude reference';
         }

--- a/src/views/show-control/OutdoorEnvironmentEditor.jsx
+++ b/src/views/show-control/OutdoorEnvironmentEditor.jsx
@@ -96,13 +96,13 @@ const OutdoorEnvironmentEditor = ({
           <Select
             value={
               (altitudeReference ? altitudeReference.type : null) ||
-              ALTITUDE_REFERENCE.AGL
+              ALTITUDE_REFERENCE.AHL
             }
             inputProps={{ id: 'altitude-reference-type' }}
             onChange={onAltitudeReferenceTypeChanged}
           >
-            <MenuItem value={ALTITUDE_REFERENCE.AGL}>
-              Altitude above ground level (AGL)
+            <MenuItem value={ALTITUDE_REFERENCE.AHL}>
+              Altitude above home level (AHL)
             </MenuItem>
             <MenuItem value={ALTITUDE_REFERENCE.AMSL}>
               Altitude above mean sea level (AMSL)

--- a/src/views/show-control/OutdoorEnvironmentEditor.jsx
+++ b/src/views/show-control/OutdoorEnvironmentEditor.jsx
@@ -101,6 +101,9 @@ const OutdoorEnvironmentEditor = ({
             inputProps={{ id: 'altitude-reference-type' }}
             onChange={onAltitudeReferenceTypeChanged}
           >
+            <MenuItem value={ALTITUDE_REFERENCE.AGL}>
+              Altitude above ground level (AGL)
+            </MenuItem>
             <MenuItem value={ALTITUDE_REFERENCE.AHL}>
               Altitude above home level (AHL)
             </MenuItem>

--- a/src/views/show-control/OutdoorEnvironmentEditor.jsx
+++ b/src/views/show-control/OutdoorEnvironmentEditor.jsx
@@ -101,9 +101,6 @@ const OutdoorEnvironmentEditor = ({
             inputProps={{ id: 'altitude-reference-type' }}
             onChange={onAltitudeReferenceTypeChanged}
           >
-            <MenuItem value={ALTITUDE_REFERENCE.AGL}>
-              Altitude above ground level (AGL)
-            </MenuItem>
             <MenuItem value={ALTITUDE_REFERENCE.AHL}>
               Altitude above home level (AHL)
             </MenuItem>

--- a/src/views/uavs/DroneStatusLine.jsx
+++ b/src/views/uavs/DroneStatusLine.jsx
@@ -173,6 +173,11 @@ const DroneStatusLine = ({
               !isNil(position && position.ahl) ? position.ahl.toFixed(1) : '?',
               5
             ) +
+            'm ' +
+            padStart(
+              !isNil(position && position.agl) ? position.agl.toFixed(1) : '?',
+              5
+            ) +
             'm'
           ) : (
             <span className={classes.muted}>{'   ———    ——— '}</span>
@@ -215,6 +220,7 @@ DroneStatusLine.propTypes = {
     lon: PropTypes.number,
     amsl: PropTypes.number,
     ahl: PropTypes.number,
+    agl: PropTypes.number,
   }),
   secondaryLabel: PropTypes.string,
   text: PropTypes.string,

--- a/src/views/uavs/DroneStatusLine.jsx
+++ b/src/views/uavs/DroneStatusLine.jsx
@@ -170,7 +170,7 @@ const DroneStatusLine = ({
             ) +
             'm ' +
             padStart(
-              !isNil(position && position.agl) ? position.agl.toFixed(1) : '?',
+              !isNil(position && position.ahl) ? position.ahl.toFixed(1) : '?',
               5
             ) +
             'm'
@@ -214,7 +214,7 @@ DroneStatusLine.propTypes = {
     lat: PropTypes.number,
     lon: PropTypes.number,
     amsl: PropTypes.number,
-    agl: PropTypes.number,
+    ahl: PropTypes.number,
   }),
   secondaryLabel: PropTypes.string,
   text: PropTypes.string,

--- a/src/views/uavs/SortAndFilterHeader.jsx
+++ b/src/views/uavs/SortAndFilterHeader.jsx
@@ -207,8 +207,8 @@ const COMMON_HEADER_TEXT_PARTS = Object.freeze([
     },
   },
   {
-    label: 'AGL',
-    sortKey: UAVSortKey.ALTITUDE_GROUND,
+    label: 'AHL',
+    sortKey: UAVSortKey.ALTITUDE_HOME,
     style: {
       textAlign: 'right',
       width: 56,

--- a/src/views/uavs/SortAndFilterHeader.jsx
+++ b/src/views/uavs/SortAndFilterHeader.jsx
@@ -215,6 +215,14 @@ const COMMON_HEADER_TEXT_PARTS = Object.freeze([
     },
   },
   {
+    label: 'AGL',
+    sortKey: UAVSortKey.ALTITUDE_GROUND,
+    style: {
+      textAlign: 'right',
+      width: 56,
+    },
+  },
+  {
     label: 'Hdg',
     sortKey: UAVSortKey.HEADING,
     style: {


### PR DESCRIPTION
Since flockwave-gps 2.3.1, flockwave-spec 1.70.0 and skybrush-server 2.10.11 the previous misnamed treatment of altitudes is finally corrected and now coordinates are expressed either as AHL (above home level, usually measured by pressure sensor etc.) or AGL (above ground level, usually measured by proximity sensors etc.). Previous references to AHL altitudes were incorrectly named as AGL due to an early Flat Earth assumption throughout the system. This pull request replaces all misnamed occurrences of AGL and ground-reference to AHL and home-reference, along with the protocol changes of the above mentioned versions of the backend.