### PR TITLE
fix: @collmot/ol-react package checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1950,7 +1950,7 @@
     "node_modules/@collmot/ol-react": {
       "version": "4.1.0",
       "resolved": "https://npm.collmot.com/@collmot%2fol-react/-/ol-react-4.1.0.tgz",
-      "integrity": "sha512-avUiLDA9xXmcSL+iw+XFt8btlIeq09RXY1sx/Jb1Rfd7Wbb1WIhei9/bIVn0bkGPManbB7N2klrs16trAqYTtA==",
+      "integrity": "sha512-nXf7lVPOIoj0v1k960QLfdoHiV39J9bCT9vRQ9M/VB79eOvEVwPVREoKK6/EexCAX7C9ApBTYMJF2YuQYa5OFw==",
       "license": "MIT",
       "peerDependencies": {
         "ol": "^9",


### PR DESCRIPTION
Assuming a new version was uploaded to the private collmot npm registry and the mismatching checksum can just be updated
```
npm warn tarball tarball data for @collmot/ol-react@https://npm.collmot.com/@collmot%2fol-react/-/ol-react-4.1.0.tgz (sha512-avUiLDA9xXmcSL+iw+XFt8btlIeq09RXY1sx/Jb1Rfd7Wbb1WIhei9/bIVn0bkGPManbB7N2klrs16trAqYTtA==) seems to be corrupted. Trying again.
```

```
➜  live git:(main) npm i
npm warn skipping integrity check for git dependency ssh://git@github.com/dmarcos/three-bmfont-text.git
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated @babel/plugin-proposal-class-properties@7.18.6: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported
npm warn deprecated @humanwhocodes/config-array@0.13.0: Use @eslint/config-array instead
npm warn deprecated rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
npm warn deprecated @humanwhocodes/object-schema@2.0.3: Use @eslint/object-schema instead
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn tarball tarball data for @collmot/ol-react@https://npm.collmot.com/@collmot%2fol-react/-/ol-react-4.1.0.tgz (sha512-avUiLDA9xXmcSL+iw+XFt8btlIeq09RXY1sx/Jb1Rfd7Wbb1WIhei9/bIVn0bkGPManbB7N2klrs16trAqYTtA==) seems to be corrupted. Trying again.
npm warn deprecated boolean@3.2.0: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
npm warn tarball tarball data for @collmot/ol-react@https://npm.collmot.com/@collmot%2fol-react/-/ol-react-4.1.0.tgz (sha512-avUiLDA9xXmcSL+iw+XFt8btlIeq09RXY1sx/Jb1Rfd7Wbb1WIhei9/bIVn0bkGPManbB7N2klrs16trAqYTtA==) seems to be corrupted. Trying again.
npm warn deprecated @material-ui/styles@4.11.5: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
npm warn deprecated @material-ui/pickers@3.3.11: This package no longer supported. It has been relaced by @mui/x-date-pickers
npm warn deprecated react-beautiful-dnd@13.1.1: react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672
npm warn deprecated @material-ui/lab@4.0.0-alpha.61: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
npm warn deprecated eslint@8.57.1: This version is no longer supported. Please see https://eslint.org/version-support for other options.
npm warn deprecated @material-ui/core@4.12.4: Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.
npm error code EINTEGRITY
npm error sha512-avUiLDA9xXmcSL+iw+XFt8btlIeq09RXY1sx/Jb1Rfd7Wbb1WIhei9/bIVn0bkGPManbB7N2klrs16trAqYTtA== integrity checksum failed when using sha512: wanted sha512-avUiLDA9xXmcSL+iw+XFt8btlIeq09RXY1sx/Jb1Rfd7Wbb1WIhei9/bIVn0bkGPManbB7N2klrs16trAqYTtA== but got sha512-nXf7lVPOIoj0v1k960QLfdoHiV39J9bCT9vRQ9M/VB79eOvEVwPVREoKK6/EexCAX7C9ApBTYMJF2YuQYa5OFw==. (43666 bytes)