### PR TITLE
Show user-defined features in non-selectable, read-only state in the site survey dialog

### DIFF
--- a/src/components/dialogs/site-survey/map/Map.tsx
+++ b/src/components/dialogs/site-survey/map/Map.tsx
@@ -29,6 +29,8 @@ import ShowInfoLayerPresentation, {
   landingPositionPoints,
   orientationMarker,
 } from '~/components/map/layers/ShowInfoLayer';
+import { FeaturesLayer } from '~/components/map/layers/features';
+import { noMark } from '~/components/map/layers/utils';
 import { Tool } from '~/components/map/tools';
 import {
   updateModifiedFeatures as updateModifiedFeaturesAction,
@@ -118,6 +120,9 @@ const ConnectedShowInfoLayer = connect((state: RootState) => ({
 
 const layerComponents = {
   ...defaultLayerComponent,
+  [LayerType.FEATURES]: (props: LayerProps) => (
+    <FeaturesLayer {...props} layerRefHandler={noMark} />
+  ),
   [LayerType.MISSION_INFO]: ConnectedShowInfoLayer,
 };
 

--- a/src/components/map/layers/features.jsx
+++ b/src/components/map/layers/features.jsx
@@ -15,6 +15,8 @@ import {
   source,
 } from '@collmot/ol-react';
 
+import { escapeKeyDown } from '~/components/map/conditions';
+import { markAsSelectableAndEditable } from '~/components/map/layers/utils';
 import { Tool } from '~/components/map/tools';
 import {
   getFeaturesInOrder,
@@ -29,7 +31,6 @@ import { getGeofencePolygonId } from '~/features/mission/selectors';
 import { showError } from '~/features/snackbar/actions';
 import { FeatureType, LabelStyle } from '~/model/features';
 import { featureIdToGlobalId } from '~/model/identifiers';
-import { setLayerEditable, setLayerSelectable } from '~/model/layers';
 import { mapViewCoordinateFromLonLat, measureFeature } from '~/utils/geography';
 import { closePolygon, euclideanDistance2D } from '~/utils/math';
 import {
@@ -40,8 +41,6 @@ import {
   whiteThickOutline,
   whiteThinOutline,
 } from '~/utils/styles';
-
-import { escapeKeyDown } from '~/components/map/conditions';
 
 // === Helper functions ===
 
@@ -335,23 +334,17 @@ const Feature = connect(
 
 // === The actual layer to be rendered ===
 
-function markAsSelectableAndEditable(layer) {
-  if (layer) {
-    setLayerEditable(layer.layer);
-    setLayerSelectable(layer.layer);
-  }
-}
-
 const FeaturesLayerPresentation = ({
   features,
   onError,
   onFeatureModificationStarted,
   onFeaturesModified,
   selectedTool,
+  layerRefHandler = markAsSelectableAndEditable,
   zIndex,
 }) => (
   <layer.Vector
-    ref={markAsSelectableAndEditable}
+    ref={layerRefHandler}
     updateWhileAnimating
     updateWhileInteracting
     zIndex={zIndex}
@@ -377,6 +370,7 @@ const FeaturesLayerPresentation = ({
 FeaturesLayerPresentation.propTypes = {
   selectedTool: PropTypes.string,
   zIndex: PropTypes.number,
+  layerRefHandler: PropTypes.func,
 
   features: PropTypes.arrayOf(PropTypes.object).isRequired,
 

--- a/src/components/map/layers/utils.ts
+++ b/src/components/map/layers/utils.ts
@@ -1,9 +1,22 @@
 import type { Layer as OLLayer } from 'ol/layer';
 
-import { setLayerSelectable } from '~/model/layers';
+import { setLayerEditable, setLayerSelectable } from '~/model/layers';
 
-export function markAsSelectable(layer?: { layer: OLLayer } | null) {
+type MaybeLayerRef = { layer: OLLayer } | undefined | null;
+
+export function noMark(layer?: MaybeLayerRef) {
+  // do nothing
+}
+
+export function markAsSelectable(layer?: MaybeLayerRef) {
   if (layer) {
+    setLayerSelectable(layer.layer);
+  }
+}
+
+export function markAsSelectableAndEditable(layer?: MaybeLayerRef) {
+  if (layer) {
+    setLayerEditable(layer.layer);
     setLayerSelectable(layer.layer);
   }
 }

--- a/src/views/map/layers/index.js
+++ b/src/views/map/layers/index.js
@@ -4,11 +4,11 @@ import {
   layerComponents,
   layerSettingsComponents,
 } from '~/components/map/layers';
+import { FeaturesLayer } from '~/components/map/layers/features';
 import { LayerType } from '~/model/layers';
 
 import { BeaconsLayer } from './beacons';
 import { DocksLayer } from './docks';
-import { FeaturesLayer } from './features';
 import { GeoJSONLayer, GeoJSONLayerSettings } from './geojson';
 import { HeatmapLayer, HeatmapLayerSettings } from './heatmap';
 import { HexGridLayer, HexGridLayerSettings } from './hexgrid';

--- a/src/views/map/layers/mission-info.jsx
+++ b/src/views/map/layers/mission-info.jsx
@@ -18,6 +18,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormGroup from '@material-ui/core/FormGroup';
 
 import Colors from '~/components/colors';
+import { styleForPointsOfPolygon } from '~/components/map/layers/features';
 import {
   convexHullPolygon,
   ConvexHullVariant,
@@ -26,6 +27,7 @@ import {
   orientationMarker,
   TAKEOFF_LANDING_POSITION_CHARACTER_WIDTH,
 } from '~/components/map/layers/ShowInfoLayer';
+import { markAsSelectableAndEditable } from '~/components/map/layers/utils';
 import { Tool } from '~/components/map/tools';
 import { setLayerParametersById } from '~/features/map/layers';
 import {
@@ -54,7 +56,6 @@ import {
   originIdToGlobalId,
   plannedTrajectoryIdToGlobalId,
 } from '~/model/identifiers';
-import { setLayerEditable, setLayerSelectable } from '~/model/layers';
 import { MissionItemType } from '~/model/missions';
 import { getMapOriginRotationAngle } from '~/selectors/map';
 import { getSelection } from '~/selectors/selection';
@@ -76,8 +77,6 @@ import {
 } from '~/utils/styles';
 import MissionSlotTrajectoryFeature from '~/views/map/features/MissionSlotTrajectoryFeature';
 import UAVTrajectoryFeature from '~/views/map/features/UAVTrajectoryFeature';
-
-import { styleForPointsOfPolygon } from './features';
 
 import mapMarkerOutline from '~/../assets/img/map-marker-outline.svg';
 import mapMarker from '~/../assets/img/map-marker.svg';
@@ -201,13 +200,6 @@ export const MissionInfoLayerSettings = connect(
 )(MissionInfoLayerSettingsPresentation);
 
 // === The actual layer to be rendered ===
-
-function markAsSelectableAndEditable(layer) {
-  if (layer) {
-    setLayerEditable(layer.layer);
-    setLayerSelectable(layer.layer);
-  }
-}
 
 /**
  * Styling for stroke of the X axis of the coordinate system.


### PR DESCRIPTION
I planned to rewrite this layer in TS in a slightly more modular form, but it would have needed some changes that I wasn't comfortable doing right now (mostly extra checks and typing around `olFeature.getGeometry().getCoordinates()`), so in the end I simply moved the existing features layer to `components/map/layers` and made it possible to change whether features can be selected and edited or not (features remain editable in Map view, but read-only in the site survey dialog).