### PR TITLE
Channel indicator & hotkey

### DIFF
--- a/src/components/header/ChannelIndicator.jsx
+++ b/src/components/header/ChannelIndicator.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { connect } from 'react-redux';
+import { makeStyles } from '@material-ui/core/styles';
+
+import { getPreferredCommunicationChannelIndex } from '~/features/mission/selectors';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    position: 'absolute',
+    bottom: 5,
+    right: 5,
+    color: 'white',
+    width: 16,
+    height: 16,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: 11,
+  },
+}));
+
+const ChannelIndicator = ({ channel }) => {
+  const classes = useStyles();
+  return <div className={classes.root}>{channel}</div>;
+};
+
+ChannelIndicator.propTypes = {
+  channel: PropTypes.number.isRequired,
+};
+
+export default connect(
+  (state) => ({
+    channel: getPreferredCommunicationChannelIndex(state) + 1,
+  })
+)(ChannelIndicator);

--- a/src/components/header/ConnectionStatusButton.jsx
+++ b/src/components/header/ConnectionStatusButton.jsx
@@ -8,6 +8,7 @@ import LazyTooltip from '@skybrush/mui-components/lib/LazyTooltip';
 import ConnectionStatusMiniList from '~/components/ConnectionStatusMiniList';
 import ConnectionStatusBadge from '~/components/badges/ConnectionStatusBadge';
 import { isConnected } from '~/features/servers/selectors';
+import ChannelIndicator from '~/components/header/ChannelIndicator';
 
 const ConnectionStatusButtonPresentation = (props) => (
   <LazyTooltip
@@ -18,6 +19,7 @@ const ConnectionStatusButtonPresentation = (props) => (
     <GenericHeaderButton {...props}>
       <ConnectionStatusBadge />
       <SettingsEthernet />
+      <ChannelIndicator />
     </GenericHeaderButton>
   </LazyTooltip>
 );

--- a/src/features/hotkeys/AppHotkeys.jsx
+++ b/src/features/hotkeys/AppHotkeys.jsx
@@ -16,6 +16,7 @@ import {
   toggleBroadcast,
   toggleDeveloperMode,
 } from '~/features/session/actions';
+import { togglePreferredChannel } from '~/features/mission/slice';
 import { isBroadcast } from '~/features/session/selectors';
 import { toggleMissionIds } from '~/features/settings/slice';
 import { requestRemovalOfSelectedUAVs } from '~/features/uavs/actions';
@@ -145,6 +146,7 @@ export default connect(
         SEND_RTH_COMMAND: callUAVActionOnSelection('returnToHome'),
         SHOW_HOTKEY_DIALOG: showHotkeyDialog,
         TOGGLE_BROADCAST_MODE: toggleBroadcast,
+        TOGGLE_PREFERRED_CHANNEL: togglePreferredChannel,
         TOGGLE_DEVELOPER_MODE: toggleDeveloperMode,
         TOGGLE_SORT_BY_MISSION_ID: toggleMissionIds,
         TYPE_0: () => appendToPendingUAVId(0),

--- a/src/features/hotkeys/keymap.js
+++ b/src/features/hotkeys/keymap.js
@@ -87,6 +87,11 @@ const globalKeyMap = {
     sequence: 'mod+b',
   },
 
+  TOGGLE_PREFERRED_CHANNEL: {
+    name: 'Toggle the preferred channel switch',
+    sequence: 'c',
+  },
+
   TOGGLE_DEVELOPER_MODE: {
     name: 'Toggle the developer mode switch',
     sequence: 'mod+shift+d',


### PR DESCRIPTION
Adds a little indicator (number "1" or "2") to show the active channel without having to open the menu.
Also adds a shortcut to toggle between the channels.

<img width="378" alt="image" src="https://github.com/user-attachments/assets/a36132cb-4eba-4626-a8a2-f6906d766324" />
