### PR TITLE
UAV status panel

### DIFF
--- a/src/components/uavs/UAVStatusSummary.jsx
+++ b/src/components/uavs/UAVStatusSummary.jsx
@@ -160,7 +160,7 @@ const showUAVsList = (workbench, dispatch) => () => {
     return;
   }
 
-  if (!workbench.bringToFront('uavs')) {
+  if (!workbench.bringToFront('uavList')) {
     dispatch(
       showNotification({
         message: 'UAVs panel is not added to the workbench yet',

--- a/src/features/rtk/RTKStatusPanel.jsx
+++ b/src/features/rtk/RTKStatusPanel.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import RTKStatusMiniList from '~/features/rtk/RTKStatusMiniList';
+
+const RTKStatusPanel = () => (
+  <div style={{ padding: '16px' }}>
+    <RTKStatusMiniList />
+  </div>
+);
+
+export default RTKStatusPanel;

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -111,6 +111,12 @@ const Sidebar = ({
           label={t('view.uav-list')}
           component='uav-list'
         />
+        <Module
+          id='uavStatuses'
+          icon={<ConnectingAirports />}
+          label={t('view.uav-statuses')}
+          component='uav-statuses'
+        />
         {hasFeature('beacons') && (
           <Module
             id='beacons'

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -27,6 +27,7 @@ import { getMissionType } from '~/features/mission/selectors';
 import { areExperimentalFeaturesEnabled } from '~/features/settings/selectors';
 import Antenna from '~/icons/Antenna';
 import ConnectingAirports from '~/icons/ConnectingAirports';
+import Satellite from '~/icons/Satellite';
 import Route from '~/icons/Route';
 import ShapeLine from '~/icons/ShapeLine';
 import { MissionType } from '~/model/missions';
@@ -116,6 +117,12 @@ const Sidebar = ({
           icon={<ConnectingAirports />}
           label={t('view.uav-statuses')}
           component='uav-statuses'
+        />
+        <Module
+          id='rtkStatuses'
+          icon={<Satellite />}
+          label={t('view.rtk-statuses')}
+          component='rtk-statuses'
         />
         {hasFeature('beacons') && (
           <Module

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -689,7 +689,8 @@
     "show-control": "Show control",
     "three-d-view": "3D View",
     "uav-details": "UAV details",
-    "uav-list": "UAVs"
+    "uav-list": "UAVs",
+    "uav-statuses": "UAV statuses"
   },
   "weatherMiniList": {
     "compassDeclination": "Compass declination",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -685,6 +685,7 @@
     "log-panel": "Event log",
     "map": "Map",
     "mission-editor": "Mission editor",
+    "rtk-statuses": "RTK statuses",
     "saved-location-list": "Locations",
     "show-control": "Show control",
     "three-d-view": "3D View",

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -19,6 +19,7 @@ import MissionOverviewPanel from './mission-editor';
 import ShowControlPanel from './show-control';
 import UAVDetailsPanel from './uav-details';
 import UAVList from './uavs';
+import UAVStatusPanel from './uavs/UAVStatusPanel';
 import ThreeDTopLevelView from './three-d';
 
 /* MapView not included as it is loaded lazily */
@@ -41,6 +42,7 @@ const views = {
   UAVDetailsPanel,
   UAVList,
   ThreeDTopLevelView,
+  UAVStatusPanel,
 };
 
 export default views;

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -20,6 +20,7 @@ import ShowControlPanel from './show-control';
 import UAVDetailsPanel from './uav-details';
 import UAVList from './uavs';
 import UAVStatusPanel from './uavs/UAVStatusPanel';
+import RTKStatusPanel from '../features/rtk/RTKStatusPanel';
 import ThreeDTopLevelView from './three-d';
 
 /* MapView not included as it is loaded lazily */
@@ -43,6 +44,7 @@ const views = {
   UAVList,
   ThreeDTopLevelView,
   UAVStatusPanel,
+  RTKStatusPanel,
 };
 
 export default views;

--- a/src/views/uavs/UAVStatusPanel.jsx
+++ b/src/views/uavs/UAVStatusPanel.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import UAVStatusMiniList from '~/components/uavs/UAVStatusMiniList';
+
+const UAVStatusPanel = () => (
+  <div style={{ padding: '16px' }}>
+    <UAVStatusMiniList />
+  </div>
+);
+
+export default UAVStatusPanel;

--- a/src/workbench.js
+++ b/src/workbench.js
@@ -173,6 +173,11 @@ export const componentRegistry = {
     label: 'UAVs',
     detachable: true,
   },
+  'uav-statuses': {
+    component: views.UAVStatusPanel,
+    label: 'UAV Statuses',
+    detachable: true,
+  },
 };
 
 function constructDefaultWorkbench(store) {

--- a/src/workbench.js
+++ b/src/workbench.js
@@ -178,6 +178,11 @@ export const componentRegistry = {
     label: 'UAV Statuses',
     detachable: true,
   },
+  'rtk-statuses': {
+    component: views.RTKStatusPanel,
+    label: 'RTK Statuses',
+    detachable: true,
+  },
 };
 
 function constructDefaultWorkbench(store) {


### PR DESCRIPTION
Adds a panel for the UAV statuses which is useful for show recordings as now this is only visible when hovering over the UAV status summary header item.
<img width="2056" alt="image" src="https://github.com/user-attachments/assets/ef348810-c30e-46eb-932b-c59dd57419e7" />
