### PR TITLE
feat: optionally restrict UploadDialog to global selection

### DIFF
--- a/src/features/mission/selectors.ts
+++ b/src/features/mission/selectors.ts
@@ -294,19 +294,6 @@ export const getUAVIdsParticipatingInMission: AppSelector<Array<UAV['id']>> =
   );
 
 /**
- * Returns a list of all the UAV IDs that participate in the mission, without
- * the null entries, sorted in ascending order by their mission indices.
- * (In other words, UAV IDs that correspond to earlier slots in the mission
- * mapping are returned first).
- *
- * Note that this also includes the IDs of UAVs that are currently not seen
- * by the server but are nevertheless in the mapping.
- */
-export const getUAVIdsParticipatingInMissionSortedByMissionIndex: AppSelector<
-  Array<UAV['id']>
-> = createSelector(getMissionMapping, (mapping) => rejectNullish(mapping));
-
-/**
  * Returns whether there is at least one non-empty mapping slot in the mapping.
  */
 export const hasNonemptyMappingSlot: AppSelector<boolean> = createSelector(

--- a/src/features/upload/UploadDialog.tsx
+++ b/src/features/upload/UploadDialog.tsx
@@ -1,13 +1,16 @@
 import isNil from 'lodash-es/isNil';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import Box from '@material-ui/core/Box';
+import Switch from '@material-ui/core/Switch';
 
 import DraggableDialog from '@skybrush/mui-components/lib/DraggableDialog';
 
 import { JOB_TYPE as FIRMWARE_UPDATE_JOB_TYPE } from '~/features/firmware-update/constants';
 import FirmwareUpdateSupportFetcher from '~/features/firmware-update/FirmwareUpdateSupportFetcher';
+import type { RootState } from '~/store/reducers';
 
 import {
   closeUploadDialogAndStepBack,
@@ -19,10 +22,10 @@ import {
   getRunningUploadJobType,
   getSelectedJobInUploadDialog,
   getUploadDialogState,
+  shouldRestrictToGlobalSelection,
 } from './selectors';
-import { closeUploadDialog } from './slice';
+import { closeUploadDialog, toggleRestrictToGlobalSelection } from './slice';
 import UploadPanel from './UploadPanel';
-import type { RootState } from '~/store/reducers';
 
 type UploadDialogProps = Readonly<{
   canGoBack: boolean;
@@ -31,28 +34,44 @@ type UploadDialogProps = Readonly<{
   onStartUpload: () => void;
   onStepBack: () => void;
   open: boolean;
+  restrictToGlobalSelection: boolean;
   runningJobType?: string;
   selectedJobType?: string;
+  toggleRestrictToGlobalSelection: () => void;
 }>;
 
 const UploadDialog = ({
   canGoBack,
   canStartUpload,
+  restrictToGlobalSelection,
   onClose,
   onStartUpload,
   onStepBack,
   open,
   runningJobType,
   selectedJobType,
+  toggleRestrictToGlobalSelection,
 }: UploadDialogProps): JSX.Element => {
+  const { t } = useTranslation();
   const isRunningJobTypeMatching =
     !runningJobType || runningJobType === selectedJobType;
+
   return (
     <DraggableDialog
       fullWidth
       open={Boolean(open)}
       maxWidth='md'
+      minHeight='md'
       title={getDialogTitleForJobType(selectedJobType ?? '')}
+      titleComponents={
+        <>
+          {t('uploadDialog.restrictToGlobalSelection')}
+          <Switch
+            checked={restrictToGlobalSelection}
+            onChange={() => toggleRestrictToGlobalSelection()}
+          />
+        </>
+      }
       onClose={onClose}
     >
       {selectedJobType === FIRMWARE_UPDATE_JOB_TYPE && (
@@ -81,6 +100,7 @@ export default connect(
       open,
       canGoBack: !isNil(backAction),
       canStartUpload: true,
+      restrictToGlobalSelection: shouldRestrictToGlobalSelection(state),
       runningJobType: getRunningUploadJobType(state),
       selectedJobType: getSelectedJobInUploadDialog(state)?.type,
     };
@@ -90,5 +110,6 @@ export default connect(
     onClose: closeUploadDialog,
     onStartUpload: startUploadJobFromUploadDialog,
     onStepBack: closeUploadDialogAndStepBack,
+    toggleRestrictToGlobalSelection,
   }
 )(UploadDialog);

--- a/src/features/upload/actions.js
+++ b/src/features/upload/actions.js
@@ -1,19 +1,18 @@
 import delay from 'delay';
 import isNil from 'lodash-es/isNil';
-import { getUAVIdsParticipatingInMissionSortedByMissionIndex } from '~/features/mission/selectors';
-import {
-  getSingleSelectedUAVIdAsArray,
-  getUAVIdList,
-} from '~/features/uavs/selectors';
-import { getScopeForJobType, JobScope } from './jobs';
 
+import { getSingleSelectedUAVIdAsArray } from '~/features/uavs/selectors';
+
+import { getScopeForJobType, JobScope } from './jobs';
 import {
   areItemsInUploadBacklog,
   getObjectIdsCompatibleWithSelectedJobInUploadDialog,
   getFailedUploadItems,
   getItemsInUploadBacklog,
+  getMissionUAVIdsForUploadJob,
   getSelectedJobInUploadDialog,
   getSuccessfulUploadItems,
+  getUAVIdList,
   getUploadDialogState,
   isItemInUploadBacklog,
   isUploadInProgress,
@@ -146,7 +145,7 @@ export function startUploadJobFromUploadDialog() {
         break;
 
       case JobScope.MISSION:
-        selector = getUAVIdsParticipatingInMissionSortedByMissionIndex;
+        selector = getMissionUAVIdsForUploadJob;
         break;
 
       case JobScope.SINGLE:

--- a/src/features/upload/selectors.ts
+++ b/src/features/upload/selectors.ts
@@ -7,12 +7,18 @@ import { createSelector } from '@reduxjs/toolkit';
 import { Status } from '~/components/semantics';
 import { JOB_TYPE as FIRMWARE_UPDATE_JOB_TYPE } from '~/features/firmware-update/constants';
 import { getSupportingObjectIdsForTargetId } from '~/features/firmware-update/selectors';
+import { getMissionMapping as _getFullMissionMapping } from '~/features/mission/selectors';
+import { getUAVIdList as _getAllKnownUAVIds } from '~/features/uavs/selectors';
+import { uavIdToGlobalId } from '~/model/identifiers';
+import type UAV from '~/model/uav';
+import { getSelection } from '~/selectors/selection';
+import type { RootState } from '~/store/reducers';
+import { rejectNullish } from '~/utils/arrays';
+import { formatMissionId } from '~/utils/formatting';
 
 import { getScopeForJobType, JobScope } from './jobs';
-import type { RootState } from '~/store/reducers';
 import type { JobPayload, UploadJob } from './types';
 import type { UploadSliceState } from './slice';
-import type UAV from '~/model/uav';
 
 /**
  * Returns the current upload job. The returned object is guaranteed to have
@@ -125,6 +131,23 @@ export const getUploadDialogState = (
 ): UploadSliceState['dialog'] => state.upload.dialog;
 
 /**
+ * Returns whether failed uploads should be retried automatically.
+ */
+export const shouldRetryFailedUploadsAutomatically = (
+  state: RootState
+): boolean => Boolean(state.upload.settings?.autoRetry);
+
+/**
+ * Returns whether the UAVs that failed the upload should be instructed to
+ * flash their lights.
+ */
+export const shouldFlashLightsOfFailedUploads = (state: RootState): boolean =>
+  Boolean(state.upload.settings?.flashFailed);
+
+export const shouldRestrictToGlobalSelection = (state: RootState): boolean =>
+  Boolean(state.upload.settings.restrictToGlobalSelection);
+
+/**
  * Returns the selected job in the upload dialog.
  */
 export const getSelectedJobInUploadDialog = (
@@ -140,23 +163,71 @@ export const getScopeOfSelectedJobInUploadDialog = createSelector(
   ({ type }) => (type ? getScopeForJobType(type) : JobScope.ALL)
 );
 
+export const getMissionIdFormatter = createSelector(
+  _getFullMissionMapping,
+  (missionMapping) => {
+    const idMap = missionMapping.reduce(
+      (res, id, index) => {
+        if (id === null) {
+          return res;
+        }
+
+        res[id] = formatMissionId(index);
+        return res;
+      },
+      {} as Record<string, string>
+    );
+
+    return (id: string): string => idMap[id] ?? 'N/A';
+  }
+);
+
+export const getMissionMapping = createSelector(
+  _getFullMissionMapping,
+  getSelection,
+  shouldRestrictToGlobalSelection,
+  (missionMapping, selection, restrictToGlobalSelection) => {
+    if (!restrictToGlobalSelection) {
+      return missionMapping;
+    }
+
+    const allowedIds = new Set(selection);
+    return missionMapping.filter(
+      (id) => id !== null && allowedIds.has(uavIdToGlobalId(id))
+    );
+  }
+);
+
 export const getObjectIdsCompatibleWithSelectedJobInUploadDialog = (
   state: RootState
 ): string[] => {
   const job = getSelectedJobInUploadDialog(state);
+  const selection = getSelection(state);
+  const restrictToGlobalSelection = shouldRestrictToGlobalSelection(state);
+
+  let result: string[];
 
   switch (job.type) {
-    case FIRMWARE_UPDATE_JOB_TYPE:
-      return (
+    case FIRMWARE_UPDATE_JOB_TYPE: {
+      result =
         getSupportingObjectIdsForTargetId(
           state,
           (job.payload as any as { target: string }).target
-        ) ?? []
-      );
+        ) ?? [];
+
+      break;
+    }
 
     default:
       return [];
   }
+
+  if (restrictToGlobalSelection) {
+    const allowedIds = new Set(selection);
+    result = result.filter((id) => allowedIds.has(id));
+  }
+
+  return result;
 };
 
 /**
@@ -281,16 +352,37 @@ export const hasQueuedItems = (state: RootState): boolean =>
 export const isUploadInProgress = (state: RootState): boolean =>
   state.upload.currentJob.running;
 
-/**
- * Returns whether failed uploads should be retried automatically.
- */
-export const shouldRetryFailedUploadsAutomatically = (
-  state: RootState
-): boolean => Boolean(state.upload.settings?.autoRetry);
+export const getUAVIdList = createSelector(
+  _getAllKnownUAVIds,
+  getSelection,
+  shouldRestrictToGlobalSelection,
+  (allUAVIds, selection, restrictToGlobalSelection) => {
+    if (!restrictToGlobalSelection) {
+      return allUAVIds;
+    }
+
+    const allowedIds = new Set(selection);
+    return allUAVIds.filter((id) => allowedIds.has(id));
+  }
+);
 
 /**
- * Returns whether the UAVs that failed the upload should be instructed to
- * flash their lights.
+ * Returns a list of all the UAV IDs that participate in the mission and for
+ * which the upload job can be executed.
+ *
+ * Null entries are ignored.
+ *
+ * UAVs that are not in the global selection may be ignored, depending on
+ * the upload dialog's state.
+ *
+ * The result is sorted in ascending order by mission indices. (In other words,
+ * UAV IDs that correspond to earlier slots in the mission mapping are
+ * returned first).
+ *
+ * Note that this also includes the IDs of UAVs that are currently not seen
+ * by the server but are nevertheless in the mapping.
  */
-export const shouldFlashLightsOfFailedUploads = (state: RootState): boolean =>
-  Boolean(state.upload.settings?.flashFailed);
+export const getMissionUAVIdsForUploadJob = createSelector(
+  getMissionMapping,
+  (mapping) => rejectNullish(mapping).toSorted()
+);

--- a/src/features/upload/types.ts
+++ b/src/features/upload/types.ts
@@ -1,6 +1,19 @@
-import { type Identifier } from '~/utils/collections';
+import type { Identifier } from '~/utils/collections';
+import type { Nullable } from '~/utils/types';
 
 export type JobPayload = unknown;
+
+export type JobData = {
+  /**
+   * The type of the job.
+   */
+  type?: Nullable<string>;
+
+  /**
+   * The payload of the job.
+   */
+  payload?: JobPayload;
+};
 
 export type UploadJob = {
   id: Identifier;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -756,6 +756,9 @@
     "tooltip": "Toolbox",
     "uploadInProgress": "Upload in progress"
   },
+  "uploadDialog": {
+    "restrictToGlobalSelection": "Global selection only"
+  },
   "uploadPanel": {
     "cancelUpload": "Cancel upload",
     "flashLightsWhereFailed": "Flash lights of UAVs where the upload failed",

--- a/src/utils/formatting.ts
+++ b/src/utils/formatting.ts
@@ -85,23 +85,6 @@ export function formatMissionId(index: number): string {
   return `s${index + 1}`;
 }
 
-/**
- * Formats a mission-specific ID range in a consistent manner
- * that is to be used everywhere throughout the UI.
- *
- * Indices as input arguments are zero-based, but they are formatted as 1-based
- * on the UI. The start index is inclusive and the end index is exclusive.
- */
-export function formatMissionIdRange(start: number, end: number): string {
-  if (end <= start) {
-    return '';
-  } else if (end === start + 1) {
-    return formatMissionId(start);
-  } else {
-    return `${formatMissionId(start)}–${end}`;
-  }
-}
-
 export type UnitDescriptor = {
   multiplier: number;
   unit: string;


### PR DESCRIPTION
@ntamas @isti115 During the review, please pay extra attention to how selectors and actions changes. There may be some use-cases I'm not aware of (thinking of job scopes, compatible drones, etc.).

@vasarhelyi Let me know what you think about the UI.

Short summary of how the feature works:

- There's a switch component now in the top right corner of the Upload dialog with a text next to it that describes its role.
- If the switch is checked, only the drones in the application's global selection will be visible in the dialog. The checked state of this button is preserved.
- If the user haven't selected drones manually (= put them to waiting state), then the upload job will only be triggered for the visible drones. Otherwise it will be triggered for the waiting drones, disregarding whether they are visible or not.
- Row headers now show the formatted IDs of the drones in the given row (previously this only worked because every drone was displayed).

The global selection hotkeys (notably range selection) works in the dialog, so a convenient user flow is to restrict the dialog to the global selection and then 1) use range selection hotkeys to change what's visible 2) click Start 3) goto step 1 or close the dialog.