### PR TITLE
Feat/show adapt takeoff duration

### DIFF
--- a/src/features/show-configurator/AdaptParametersForm.tsx
+++ b/src/features/show-configurator/AdaptParametersForm.tsx
@@ -9,6 +9,7 @@ import FormHeader from '@skybrush/mui-components/lib/FormHeader';
 
 import {
   SimpleDistanceField,
+  SimpleDurationField,
   SimpleVelocityField,
 } from '~/components/forms/fields';
 
@@ -22,6 +23,7 @@ const defaultAdaptParameters: ShowAdaptParameters = {
   altitude: 5,
   horizontalVelocity: 5,
   verticalVelocity: 1.5,
+  takeoffDuration: 0,
 };
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -40,7 +42,8 @@ function adaptParametersValid(parameters: ShowAdaptParameters): boolean {
     parameters.minDistance > 0 &&
     parameters.altitude > 0 &&
     parameters.verticalVelocity > 0 &&
-    parameters.horizontalVelocity > 0
+    parameters.horizontalVelocity > 0 && 
+    parameters.takeoffDuration >= 0
   );
 }
 
@@ -48,6 +51,13 @@ function adaptParametersValid(parameters: ShowAdaptParameters): boolean {
  * Parses a distance (string) as meters, rounded to 3 digits.
  */
 function parseDistanceAsMeters(value: string): number {
+  return Math.round(Number.parseFloat(value) * 1000) * 0.001;
+}
+
+/**
+ * Parses a duration (string) as seconds, rounded to 3 digits.
+ */
+function parseDurationAsSeconds(value: string): number {
   return Math.round(Number.parseFloat(value) * 1000) * 0.001;
 }
 
@@ -73,6 +83,9 @@ export function useAdaptParametersFormState(
     verticalVelocity:
       defaultParameters?.verticalVelocity ??
       defaultAdaptParameters.verticalVelocity,
+    takeoffDuration:
+      defaultParameters?.takeoffDuration ??
+      defaultAdaptParameters.takeoffDuration,
   });
   const [isValid, setIsValid] = useState(adaptParametersValid(parameters));
 
@@ -128,6 +141,19 @@ export function useAdaptParametersFormState(
     },
     [onChange, parameters]
   );
+  const onTakeoffDurationChanged = useCallback(
+    (evt: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const value = parseDurationAsSeconds(evt.target.value);
+      const newParameters: ShowAdaptParameters = {
+        ...parameters,
+        takeoffDuration: value,
+      };
+      setParameters(newParameters);
+      setIsValid(adaptParametersValid(newParameters));
+      onChange?.();
+    },
+    [onChange, parameters]
+  );
 
   return {
     parameters,
@@ -136,6 +162,7 @@ export function useAdaptParametersFormState(
     onAltitudeChanged,
     onHorizontalVelocityChanged,
     onVerticalVelocityChanged,
+    onTakeoffDurationChanged,
   };
 }
 
@@ -153,6 +180,7 @@ const AdaptParametersForm = (props: Props): JSX.Element => {
     onAltitudeChanged,
     onHorizontalVelocityChanged,
     onVerticalVelocityChanged,
+    onTakeoffDurationChanged,
   } = props;
   const { t } = useTranslation(undefined, {
     keyPrefix: 'showConfiguratorDialog.adaptParameters',
@@ -197,6 +225,15 @@ const AdaptParametersForm = (props: Props): JSX.Element => {
           disabled={disabled}
           helperText={t('form.verticalVelocity.help')}
           onChange={onVerticalVelocityChanged}
+        />
+        <SimpleDurationField
+          label={t('form.takeoffDuration.label')}
+          min={0}
+          max={300}
+          value={parameters.takeoffDuration}
+          disabled={disabled}
+          helperText={t('form.takeoffDuration.help')}
+          onChange={onTakeoffDurationChanged}
         />
       </FormGroup>
     </Box>

--- a/src/features/show-configurator/ShowConfiguratorDialog.tsx
+++ b/src/features/show-configurator/ShowConfiguratorDialog.tsx
@@ -150,6 +150,8 @@ function useOwnState(props: Props) {
           minDistance: validationSettings.minDistance,
           horizontalVelocity: validationSettings.maxVelocityXY,
           verticalVelocity: validationSettings.maxVelocityZ,
+          // TODO: get takeoffDuration as the start of the show segment of the show
+          // in case user wants to keep original takeoff length
         },
     resetAdaptResult
   );

--- a/src/features/show-configurator/actions.ts
+++ b/src/features/show-configurator/actions.ts
@@ -297,12 +297,14 @@ export const adjustHomePositionsToDronePositions =
 
 type Meters = number;
 type MetersPerSecond = number;
+type Seconds = number;
 
 export type OptionalShowAdaptParameters = {
   altitude?: Meters | undefined;
   minDistance?: Meters | undefined;
   horizontalVelocity?: MetersPerSecond | undefined;
   verticalVelocity?: MetersPerSecond | undefined;
+  takeoffDuration?: Seconds | undefined;
 };
 
 export type ShowAdaptParameters = Required<OptionalShowAdaptParameters>;
@@ -334,6 +336,7 @@ export const adaptShow =
         type: 'takeoff',
         parameters: {
           positions,
+          duration: params.takeoffDuration || undefined,
           ...common,
         },
       },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -628,6 +628,10 @@
           "help": "between drones during takeoff & RTH",
           "label": "Minimum distance"
         },
+        "takeoffDuration": {
+          "help": "ensuring exact start of show phase (if nonzero)",
+          "label": "Takeoff duration"
+        },
         "verticalVelocity": {
           "help": "during takeoff & RTH phases",
           "label": "Vertical velocity"


### PR DESCRIPTION
This PR adds takeoff duration parameter to the show adapt dialog to have the option to specify explicit length for the takeoff and thus for the show start. TODOs:

- [ ] Would be nice to show the original takeoff/show/rth segment durations somewhere in the dialog for reference (if someone wants to keep the exact takeoff length, it needs two iterations now: first one shows diff, second corrected can result in diff=0)
- [ ] is the "0 means undefined" rule in the general number input box OK for takeoff duration? It was simpler to include the duration in a `createNumericField()` call than implementing a new `createOptionalNumericField()` ...