### PR TITLE
MissionInfoLayer: use min distance selectors from the show state when the app is in show context

### DIFF
--- a/src/features/show/selectors.d.ts
+++ b/src/features/show/selectors.d.ts
@@ -78,7 +78,8 @@ export const isShowConvexHullInsideGeofence: (state: RootState) => boolean;
 export const isShowIndoor: (state: RootState) => boolean;
 export const isShowOutdoor: (state: RootState) => boolean;
 export const isTakeoffAreaApproved: (state: RootState) => boolean;
-
+export const getMinimumDistanceBetweenTakeoffPositions: AppSelector<number>;
+export const getMinimumDistanceBetweenLandingPositions: AppSelector<number>;
 export const getBase64ShowBlob: AppSelector<string | undefined>;
 export const getShowSegment: AppSelector<ShowSegment | undefined>;
 export const getSwarmSpecificationForShowSegment: AppSelector<

--- a/src/views/map/layers/mission-info.jsx
+++ b/src/views/map/layers/mission-info.jsx
@@ -1,6 +1,7 @@
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormGroup from '@mui/material/FormGroup';
+import { createSelector } from '@reduxjs/toolkit';
 import dropWhile from 'lodash-es/dropWhile';
 import takeWhile from 'lodash-es/takeWhile';
 import unary from 'lodash-es/unary';
@@ -35,15 +36,18 @@ import {
   getCurrentMissionItemRatio,
   getGPSBasedHomePositionsInMission,
   getGPSBasedLandingPositionsInMission,
-  getMinimumDistanceBetweenHomePositions,
-  getMinimumDistanceBetweenLandingPositions,
+  getMinimumDistanceBetweenHomePositions as getMinimumDistanceBetweenHomePositionsInMission,
+  getMinimumDistanceBetweenLandingPositions as getMinimumDistanceBetweenLandingPositionsInMission,
   getMissionItemsOfTypeWithIndices,
   getMissionItemsWithAreasInOrder,
   getMissionItemsWithCoordinatesInOrder,
+  getMissionType,
   getSelectedMissionIndicesForTrajectoryDisplay,
 } from '~/features/mission/selectors';
 import {
   getConvexHullOfShowInWorldCoordinates,
+  getMinimumDistanceBetweenTakeoffPositions as getMinimumDistanceBetweenTakeoffPositionsInShow,
+  getMinimumDistanceBetweenLandingPositions as getMinimumDistanceBetweenLandingPositionsInShow,
   getOutdoorShowOrientation,
   getOutdoorShowOrigin,
 } from '~/features/show/selectors';
@@ -56,7 +60,7 @@ import {
   originIdToGlobalId,
   plannedTrajectoryIdToGlobalId,
 } from '~/model/identifiers';
-import { MissionItemType } from '~/model/missions';
+import { MissionItemType, MissionType } from '~/model/missions';
 import { getMapOriginRotationAngle } from '~/selectors/map';
 import { getSelection } from '~/selectors/selection';
 import { hasFeature } from '~/utils/configuration';
@@ -77,6 +81,36 @@ import {
 } from '~/utils/styles';
 import MissionSlotTrajectoryFeature from '~/views/map/features/MissionSlotTrajectoryFeature';
 import UAVTrajectoryFeature from '~/views/map/features/UAVTrajectoryFeature';
+
+// -- Custom selectors
+
+const getMinimumHomePositionDistanceSelector = createSelector(
+  getMissionType,
+  (type) =>
+    type === MissionType.SHOW
+      ? getMinimumDistanceBetweenTakeoffPositionsInShow
+      : getMinimumDistanceBetweenHomePositionsInMission
+);
+
+const getMinimumDistanceBetweenHomePositions = createSelector(
+  (state) => state,
+  getMinimumHomePositionDistanceSelector,
+  (state, selector) => selector(state)
+);
+
+const getMinimumLandingPositionDistanceSelector = createSelector(
+  getMissionType,
+  (type) =>
+    type === MissionType.SHOW
+      ? getMinimumDistanceBetweenLandingPositionsInShow
+      : getMinimumDistanceBetweenLandingPositionsInMission
+);
+
+const getMinimumDistanceBetweenLandingPositions = createSelector(
+  (state) => state,
+  getMinimumLandingPositionDistanceSelector,
+  (state, selector) => selector(state)
+);
 
 // === Settings for this particular layer type ===
 


### PR DESCRIPTION
This way, in show context, we only do 2 quick calculations instead of 2 quick and 2 long ones when a show is loaded or transformed.

The reason for putting the extra selectors to `mission-info.jsx` is that:

- some selectors in the `show` slice already depend on selectors in the `mission` slice, so adding these selectors to the `mission` slice (where they would normally belong) would create a circular dependency
- the existing min distance selectors were only used in `mission-info.jsx`.

Alternatively, we could split `mission/selectors.ts` into two files to break the circular dependency. The benefit would be that we could hide the optimization logic inside the exported `getMinimumDistance*` selectors, and then the optimization would automatically work wherever these selectors are used in the future.

Let me know what you think.

*Note: I still never tested the app in mission mode. It wouldn't hurt in this case, but this change should have no effect for that use-case.*