### PR TITLE
Fix broken styles after mui v7 upgrade

### DIFF
--- a/src/components/BatteryIndicator.jsx
+++ b/src/components/BatteryIndicator.jsx
@@ -9,35 +9,33 @@ import Colors from '~/components/colors';
 
 import { BatteryFormatter, DEFAULT_BATTERY_FORMATTER } from './battery';
 
-const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      marginTop: theme.spacing(0.5),
-      padding: '0 2px',
-      textAlign: 'center',
-      userSelect: 'none',
-      width: '100%',
-    },
+const useStyles = makeStyles((theme) => ({
+  root: {
+    marginTop: theme.spacing(0.5),
+    padding: '0 2px',
+    textAlign: 'center',
+    userSelect: 'none',
+    width: '100%',
+  },
 
-    batteryFull: {
-      color: Colors.success,
-      fontWeight: 'bold',
-    },
+  batteryFull: {
+    color: Colors.success,
+    fontWeight: 'bold',
+  },
 
-    batteryWarning: {
-      backgroundColor: Colors.warning,
-      borderRadius: `${theme.shape.borderRadius * 2}px`,
-      color: theme.palette.getContrastText(Colors.warning),
-    },
+  batteryWarning: {
+    backgroundColor: Colors.warning,
+    borderRadius: `${theme.shape.borderRadius * 2}px`,
+    color: theme.palette.getContrastText(Colors.warning),
+  },
 
-    batteryError: {
-      backgroundColor: Colors.error,
-      borderRadius: `${theme.shape.borderRadius * 2}px`,
-      color: theme.palette.getContrastText(Colors.error),
-      fontWeight: 'bold',
-    },
-  }),
-);
+  batteryError: {
+    backgroundColor: Colors.error,
+    borderRadius: `${theme.shape.borderRadius * 2}px`,
+    color: theme.palette.getContrastText(Colors.error),
+    fontWeight: 'bold',
+  },
+}));
 
 /**
  * Presentational component for a battery charge indicator.

--- a/src/components/ColoredLight.jsx
+++ b/src/components/ColoredLight.jsx
@@ -5,35 +5,33 @@ import React from 'react';
 
 import { makeStyles } from '@skybrush/app-theme-mui';
 
-const useStyles = makeStyles(
-  (theme) => ({
-    root: {
-      border: '1px solid rgba(0, 0, 0, 0.3)',
-      borderRadius: '50%',
-      color: 'black',
-      height: '1em',
-      minWidth:
-        '1em' /* needed for narrow cases; setting width alone is not enough */,
-      marginRight: theme.spacing(2),
-      position: 'relative',
-      width: '1em',
-    },
+const useStyles = makeStyles((theme) => ({
+  root: {
+    border: '1px solid rgba(0, 0, 0, 0.3)',
+    borderRadius: '50%',
+    color: 'black',
+    height: '1em',
+    minWidth:
+      '1em' /* needed for narrow cases; setting width alone is not enough */,
+    marginRight: theme.spacing(2),
+    position: 'relative',
+    width: '1em',
+  },
 
-    inline: {
-      display: 'inline-block',
-      marginRight: [0, '!important'],
-      verticalAlign: 'sub',
-    },
+  inline: {
+    display: 'inline-block',
+    marginRight: '0px !important',
+    verticalAlign: 'sub',
+  },
 
-    'size-small': {
-      fontSize: '0.75em',
-    },
+  'size-small': {
+    fontSize: '0.75em',
+  },
 
-    'size-large': {
-      fontSize: '1.25em',
-    },
-  }),
-);
+  'size-large': {
+    fontSize: '1.25em',
+  },
+}));
 
 /**
  * Small component resembling an LED light that can be set to an arbitrary

--- a/src/views/uavs/DroneListItem.tsx
+++ b/src/views/uavs/DroneListItem.tsx
@@ -54,7 +54,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 
   stretch: {
-    alignItems: ['stretch', '!important'] as any as string,
+    alignItems: 'stretch !important',
   },
 }));
 

--- a/src/views/uavs/DroneStatusLine.jsx
+++ b/src/views/uavs/DroneStatusLine.jsx
@@ -52,8 +52,8 @@ const useStyles = makeStyles((theme) => ({
     fontFamily: monospacedFont,
     fontSize: 'small',
     fontVariantNumeric: 'lining-nums tabular-nums',
-    marginTop: [-2, '!important'],
-    marginBottom: [-4, '!important'],
+    marginTop: '-2px, !important',
+    marginBottom: '-4px !important',
     userSelect: 'none',
     whiteSpace: 'pre',
   },
@@ -87,7 +87,7 @@ const useStyles = makeStyles((theme) => ({
     textAlign: 'left',
     padding: theme.spacing(0, 0.5),
     margin: theme.spacing(0, 0.5),
-    width: 56,
+    width: '56px !important',
   },
 }));
 

--- a/src/views/uavs/SortAndFilterHeader.tsx
+++ b/src/views/uavs/SortAndFilterHeader.tsx
@@ -80,14 +80,14 @@ const createChipStyle = (
     result['boxShadow'] = `0 0 4px 2px ${color}`;
     result['&:focus'] = {
       color: theme.palette.getContrastText(color),
-      backgroundColor: [lighter, '!important'],
+      backgroundColor: `${lighter} !important`,
     };
     result['&:hover'] = {
       color: theme.palette.getContrastText(color),
-      backgroundColor: [lighter, '!important'],
+      backgroundColor: `${lighter} !important`,
     };
     result['& svg'] = {
-      color: [theme.palette.getContrastText(color), '!important'],
+      color: `${theme.palette.getContrastText(color)} '!important'`,
     };
   }
 


### PR DESCRIPTION
_Edit: our `makeStyles()` doesn't understand array class declarations and it also lacks the style registry/ordering features of the mui v6 implementation (meaning we need to use `!important` in cases where we want to override the default style of a component)._