### PR TITLE
Calculate the SHA1 hash of the show specification and include it in show upload messages

### DIFF
--- a/src/features/show/upload.js
+++ b/src/features/show/upload.js
@@ -127,12 +127,12 @@ export function createShowConfigurationForUav(state, uavId) {
  * @param uavId    the ID of the UAV to upload the show trajectory to
  * @param data     the show specification, as selected from the state store
  */
-async function runSingleShowUpload({ uavId, data }) {
+async function runSingleShowUpload({ uavId, data, showHash }) {
   // No need for a timeout here; it utilizes the message hub, which has its
   // own timeout for failed command executions (although it is quite long)
   const cancelToken = messageHub.createCancelToken();
   const promise = messageHub.execute.uploadDroneShow(
-    { uavId, data },
+    { uavId, data, showHash },
     { cancelToken }
   );
   promise[CANCEL] = () => cancelToken.cancel({ allowFailure: true });

--- a/src/features/upload/jobs.ts
+++ b/src/features/upload/jobs.ts
@@ -20,6 +20,7 @@ export type JobSpecification<T> = {
       uavId: string;
       payload: JobPayload;
       data: T;
+      showHash?: Promise<string>;
     },
     options: {
       onProgress: (id: string, status: ProgressStatus) => void;
@@ -50,10 +51,11 @@ export type JobSpecification<T> = {
  *   single UAV (e.g., uploads a drone show specification to a single UAV). This
  *   function runs in the context of a worker saga, which is blocked until the
  *   promise returned from the executor resolves or rejects. The function will
- *   be called with an object having three keys: `uavId` is the ID of the UAV
+ *   be called with an object having four keys: `uavId` is the ID of the UAV
  *   that is targeted by the job, `payload` is the payload of the original job
- *   specification, and `data` is the state slice that was extracted by the
- *   selector associated to the job type. The semantics of the payload and the
+ *   specification, `data` is the state slice that was extracted by the
+ *   selector associated to the job type, and `showHash` is an optional hash
+ *   `Promise` of the show specification. The semantics of the payload and the
  *   data object depends solely on the type of the job being executed.
  *
  * It is recommended to use an executor _saga_ or to make the executor return a

--- a/src/flockwave/operations.ts
+++ b/src/flockwave/operations.ts
@@ -20,13 +20,13 @@ import {
   createParameterSettingRequest,
 } from './builders';
 import type MessageHub from './messages';
-import { extractResponseForId } from './parsing';
-import { validateExtensionName, validateObjectId } from './validation';
-import type { Message, MessageBody } from './types';
 import type {
   AsyncOperationOptions,
   AsyncResponseHandlerOptions,
 } from './messages';
+import { extractResponseForId } from './parsing';
+import type { Message, MessageBody } from './types';
+import { validateExtensionName, validateObjectId } from './validation';
 
 /**
  * Asks the server to set a new configuration object for the extension with the
@@ -231,7 +231,15 @@ export async function startRTKSurvey(
  */
 export async function uploadDroneShow(
   hub: MessageHub,
-  { uavId, data }: { uavId: string; data: string },
+  {
+    uavId,
+    data,
+    showHash,
+  }: {
+    uavId: string;
+    data: string;
+    showHash?: Promise<string>;
+  },
   options: AsyncResponseHandlerOptions
 ) {
   validateObjectId(uavId);
@@ -246,6 +254,7 @@ export async function uploadDroneShow(
         command: '__show_upload',
         kwds: {
           show: data,
+          show_hash: await showHash,
         },
       },
       {

--- a/src/utils/hashing.ts
+++ b/src/utils/hashing.ts
@@ -1,0 +1,14 @@
+/**
+ * Calculates the SHA-1 hash of the given string.
+ *
+ * Only use this function for calculating signatures. Do not use it for security purposes.
+ */
+export async function sha1(data: string): Promise<string> {
+  const encoded = new TextEncoder().encode(data);
+  const hash = await window.crypto.subtle.digest('SHA-1', encoded);
+  const uint8Hash = new Uint8Array(hash);
+  // TODO: use uint8Hash.toHex() instead when toHex() is more broadly available.
+  return Array.from(uint8Hash, (byte) =>
+    byte.toString(16).padStart(2, '0')
+  ).join('');
+}


### PR DESCRIPTION
Questions:

- What else do we need to include in the show hash calculation? Currently it's just the show spec.
- Do we need server version checks before sending the show hash? Existing drivers in the server don't support the new `show_hash` argument. See the attached diff for the minimum necessary changes in `skybrush-server`.

[skybrush-server-show-hash-support.zip](https://github.com/user-attachments/files/24764001/skybrush-server-show-hash-support.zip)
