### PR TITLE
Fix linter warnings 

### DIFF
--- a/src/features/parameters/types.ts
+++ b/src/features/parameters/types.ts
@@ -3,7 +3,7 @@ import type { Identifier } from '~/utils/collections';
 export type ParameterData = {
   name: string;
   uavId: string | undefined;
-  value: unknown;
+  value: string;
 };
 
 export type Parameter = ParameterData & {

--- a/src/features/rtk/RTKStatusHeaderButton.jsx
+++ b/src/features/rtk/RTKStatusHeaderButton.jsx
@@ -74,10 +74,7 @@ const RTKStatusHeaderButton = ({
         }
         secondaryLabel={
           surveyStatus.supported && typeof surveyStatus.accuracy === 'number'
-            ? formatSurveyAccuracy(surveyStatus.accuracy, {
-                max: 9,
-                short: true,
-              })
+            ? formatSurveyAccuracy(surveyStatus.accuracy, { max: 9 })
             : null
         }
         style={buttonStyle}

--- a/src/features/rtk/utils.ts
+++ b/src/features/rtk/utils.ts
@@ -108,10 +108,7 @@ export function describeMessageType(type: string): string {
   );
 }
 
-export function formatSurveyAccuracy(
-  value: number,
-  { max = 20, short = false } = {}
-): string {
+export function formatSurveyAccuracy(value: number, { max = 20 } = {}): string {
   if (value > max) {
     return `> ${max}m`;
   }


### PR DESCRIPTION
- remove short option of `formatSurveyAccuracy`
- `Parameter` `value` must be a string