### PR TITLE
Enable show origin transformations through interactions with the takeoff markers

### DIFF
--- a/src/components/badges/GeofenceStatusBadge.tsx
+++ b/src/components/badges/GeofenceStatusBadge.tsx
@@ -9,7 +9,7 @@ import { SidebarBadge } from '@skybrush/mui-components';
 
 import { colorForStatus } from '~/components/colors';
 import { Status } from '~/components/semantics';
-import { getGeofenceStatus } from '~/features/mission/selectors-geofence-extra';
+import { getGeofenceStatus } from '~/features/mission/selectors/geofence';
 import type { RootState } from '~/store/reducers';
 
 /**

--- a/src/components/map/interactions/TransformFeatures.js
+++ b/src/components/map/interactions/TransformFeatures.js
@@ -21,6 +21,7 @@ import { getCenterOfFirstPointsOfTrajectoriesInWorldCoordinates } from '~/featur
 import {
   GROSS_CONVEX_HULL_AREA_ID,
   globalIdToAreaId,
+  isHomePositionId,
   isOriginId,
 } from '~/model/identifiers';
 /**
@@ -141,7 +142,8 @@ export class TransformFeaturesInteraction extends PointerInteraction {
             // investigate whether there is a way around it
             if (
               globalIdToAreaId(this.lastFeature_.getId()) ===
-              GROSS_CONVEX_HULL_AREA_ID
+                GROSS_CONVEX_HULL_AREA_ID ||
+              isHomePositionId(this.lastFeature_.getId())
             ) {
               const state = store.getState();
 

--- a/src/features/mission/selectors/composed.ts
+++ b/src/features/mission/selectors/composed.ts
@@ -1,0 +1,183 @@
+import turfContains from '@turf/boolean-contains';
+import { createSelector } from '@reduxjs/toolkit';
+
+import {
+  getFeaturesById,
+  getFeaturesInOrder,
+} from '~/features/map-features/selectors';
+import { type FeatureWithProperties } from '~/features/map-features/types';
+import { selectionForSubset } from '~/features/selection/selectors';
+import {
+  globalIdToMissionItemId,
+  globalIdToMissionSlotId,
+} from '~/model/identifiers';
+import { type MissionIndex } from '~/model/missions';
+import { type AppSelector } from '~/store/reducers';
+import { type LonLat } from '~/utils/geography';
+import { createGeometryFromPoints } from '~/utils/math';
+import { EMPTY_ARRAY } from '~/utils/redux';
+
+import {
+  getConvexHullOfMissionInWorldCoordinates,
+  getGeofencePolygonId,
+  getMissionItemIds,
+} from './local';
+
+/**
+ * Selector that calculates and caches the list of selected mission item IDs from
+ * the state object.
+ */
+export const getSelectedMissionItemIds = selectionForSubset(
+  globalIdToMissionItemId
+);
+
+/**
+ * Selector that calculates and caches the list of selected mission indices from
+ * the state object.
+ */
+export const getSelectedMissionSlotIds = selectionForSubset(
+  globalIdToMissionSlotId
+);
+
+/**
+ * Selector that returns at most five selected mission indices for sake of
+ * displaying their trajectories.
+ */
+export const getSelectedMissionIndicesForTrajectoryDisplay: AppSelector<
+  MissionIndex[]
+> = createSelector(getSelectedMissionSlotIds, (selectedMissionSlotIds) =>
+  selectedMissionSlotIds.length <= 5
+    ? selectedMissionSlotIds.map(Number)
+    : EMPTY_ARRAY
+);
+
+export const getItemIndexRangeForSelectedMissionItems: AppSelector<
+  [number, number]
+> = createSelector(
+  getMissionItemIds,
+  getSelectedMissionItemIds,
+  (allIds, selectedIds) => {
+    const indices = selectedIds.map((id) => allIds.indexOf(id));
+    return [Math.min(...indices), Math.max(...indices)];
+  }
+);
+
+/**
+ * Returns whether the currently selected mission items form a single,
+ * uninterrupted chunk in the list of mission items.
+ */
+export const areSelectedMissionItemsInOneChunk: AppSelector<boolean> =
+  createSelector(
+    getItemIndexRangeForSelectedMissionItems,
+    getSelectedMissionItemIds,
+    (indexRange, selectedIds) => {
+      const [minIndex, maxIndex] = indexRange;
+      return minIndex >= 0 && maxIndex === minIndex + selectedIds.length - 1;
+    }
+  );
+
+export const createCanMoveSelectedMissionItemsByDeltaSelector = (
+  delta: number
+): AppSelector<boolean> =>
+  createSelector(
+    getMissionItemIds,
+    areSelectedMissionItemsInOneChunk,
+    getItemIndexRangeForSelectedMissionItems,
+    (allIds, inOneChunk, indexRange) => {
+      if (!inOneChunk) {
+        return false;
+      }
+
+      const [minIndex, maxIndex] = indexRange;
+      if (delta < 0) {
+        return minIndex >= Math.abs(delta);
+      } else {
+        return maxIndex + delta < allIds.length;
+      }
+    }
+  );
+
+/**
+ * Returns whether the currently selected mission items can be moved upwards
+ * by one slot.
+ */
+export const canMoveSelectedMissionItemsUp: AppSelector<boolean> =
+  createCanMoveSelectedMissionItemsByDeltaSelector(-1);
+
+/**
+ * Returns whether the currently selected mission items can be moved downwards
+ * by one slot.
+ */
+export const canMoveSelectedMissionItemsDown: AppSelector<boolean> =
+  createCanMoveSelectedMissionItemsByDeltaSelector(1);
+
+/**
+ * Gets the polygon that is to be used as a geofence.
+ */
+export const getGeofencePolygon: AppSelector<
+  FeatureWithProperties | undefined
+> = createSelector(
+  getGeofencePolygonId,
+  getFeaturesById,
+  (geofencePolygonId, featuresById) =>
+    typeof geofencePolygonId === 'string'
+      ? featuresById[geofencePolygonId]
+      : undefined
+);
+
+/**
+ * Gets the coordinates of the polygon that is to be used as a geofence, in
+ * world coordinates, or undefined if no geofence polygon is defined.
+ */
+export const getGeofencePolygonInWorldCoordinates: AppSelector<
+  LonLat[] | undefined
+> = createSelector(
+  getGeofencePolygon,
+  (geofencePolygon) => geofencePolygon?.points
+);
+
+/**
+ * Returns whether a geofence is currently set by the user (either automatically)
+ * or manually.
+ */
+export const hasActiveGeofencePolygon: AppSelector<boolean> = createSelector(
+  getGeofencePolygonId,
+  getFeaturesById,
+  (geofencePolygonId, featuresById) =>
+    geofencePolygonId !== undefined &&
+    featuresById[geofencePolygonId] !== undefined
+);
+
+export const getExclusionZonePolygons: AppSelector<FeatureWithProperties[]> =
+  createSelector(getFeaturesInOrder, (featuresInOrder) =>
+    featuresInOrder.filter((f) => f.attributes?.['isExclusionZone'])
+  );
+
+/**
+ * Returns whether the convex hull of the waypoint mission (home positions and
+ * mission items) is fully contained inside the geofence polygon.
+ */
+export const isWaypointMissionConvexHullInsideGeofence: AppSelector<
+  boolean | undefined
+> = createSelector(
+  getConvexHullOfMissionInWorldCoordinates,
+  getGeofencePolygonInWorldCoordinates,
+  (convexHullPoints, geofencePoints) => {
+    if (
+      geofencePoints !== undefined &&
+      geofencePoints.length > 0 &&
+      convexHullPoints !== undefined &&
+      convexHullPoints.length > 0
+    ) {
+      const geofence = createGeometryFromPoints(geofencePoints);
+      const convexHull = createGeometryFromPoints(convexHullPoints);
+      return (
+        geofence.isOk() &&
+        convexHull.isOk() &&
+        turfContains(geofence.value, convexHull.value)
+      );
+    } else {
+      return false;
+    }
+  }
+);

--- a/src/features/mission/selectors/geofence.js
+++ b/src/features/mission/selectors/geofence.js
@@ -11,12 +11,12 @@ import { MissionType } from '~/model/missions';
 
 import {
   getGeofencePolygon,
-  getMissionType,
   hasActiveGeofencePolygon,
   isWaypointMissionConvexHullInsideGeofence,
-} from './selectors';
+} from './composed';
+import { getMissionType } from './local';
 
-export const getGeofenceValidatorBasedOnMissionType = createSelector(
+export const isGeofenceValidBasedOnMissionType = createSelector(
   isShowConvexHullInsideGeofence,
   isWaypointMissionConvexHullInsideGeofence,
   getMissionType,
@@ -30,12 +30,12 @@ export const getGeofenceValidatorBasedOnMissionType = createSelector(
 export const getGeofenceStatus = createSelector(
   hasActiveGeofencePolygon,
   getGeofencePolygon,
-  getGeofenceValidatorBasedOnMissionType,
+  isGeofenceValidBasedOnMissionType,
   getMissionType,
-  (hasActiveGeofencePolygon, geofencePolygon, validator, missionType) => {
+  (hasActiveGeofencePolygon, geofencePolygon, geofenceValid, missionType) => {
     return !hasActiveGeofencePolygon
       ? Status.OFF
-      : !validator
+      : !geofenceValid
         ? Status.ERROR
         : geofencePolygon.owner === missionType
           ? Status.SUCCESS

--- a/src/features/mission/selectors/index.ts
+++ b/src/features/mission/selectors/index.ts
@@ -1,0 +1,2 @@
+export * from './local';
+export * from './composed';

--- a/src/features/mission/selectors/local.ts
+++ b/src/features/mission/selectors/local.ts
@@ -1,5 +1,4 @@
 import { createSelector } from '@reduxjs/toolkit';
-import turfContains from '@turf/boolean-contains';
 import * as TurfHelpers from '@turf/helpers';
 import { produce } from 'immer';
 import isNil from 'lodash-es/isNil';
@@ -7,22 +6,12 @@ import max from 'lodash-es/max';
 import range from 'lodash-es/range';
 import unary from 'lodash-es/unary';
 
-import {
-  getFeaturesById,
-  getFeaturesInOrder,
-} from '~/features/map-features/selectors';
-import { type FeatureWithProperties } from '~/features/map-features/types';
 import { GeofenceAction, isValidGeofenceAction } from '~/features/safety/model';
-import { selectionForSubset } from '~/features/selection/selectors';
 import {
   type Altitude,
   AltitudeReference,
   type GPSPosition,
 } from '~/model/geography';
-import {
-  globalIdToMissionItemId,
-  globalIdToMissionSlotId,
-} from '~/model/identifiers';
 import {
   getAltitudeFromMissionItem,
   getAreaFromMissionItem,
@@ -48,16 +37,11 @@ import {
   mapViewCoordinateFromLonLat,
   turfDistanceInMeters,
 } from '~/utils/geography';
-import {
-  convexHull2D,
-  createGeometryFromPoints,
-  estimatePathDuration,
-} from '~/utils/math';
+import { convexHull2D, estimatePathDuration } from '~/utils/math';
 import { findNearestNeighborsDistance } from '~/utils/nearestNeighbors';
-import { EMPTY_ARRAY } from '~/utils/redux';
 import { type Nullable } from '~/utils/types';
 
-import { type MissionSliceState } from './slice';
+import { type MissionSliceState } from '../slice';
 
 /**
  * Key selector function for cached selectors that cache things by mission
@@ -94,14 +78,6 @@ export const getMissionItemsAsCollection: AppSelector<
  */
 export const getMissionItemIds: AppSelector<Identifier[]> = (state) =>
   state.mission.items.order;
-
-/**
- * Selector that calculates and caches the list of selected mission item IDs from
- * the state object.
- */
-export const getSelectedMissionItemIds = selectionForSubset(
-  globalIdToMissionItemId
-);
 
 /**
  * Returns a mapping from IDs to the corresponding mission items.
@@ -263,26 +239,6 @@ export const getUAVIdForMappingSlotBeingEdited: AppSelector<
 );
 
 /**
- * Selector that calculates and caches the list of selected mission indices from
- * the state object.
- */
-export const getSelectedMissionSlotIds = selectionForSubset(
-  globalIdToMissionSlotId
-);
-
-/**
- * Selector that returns at most five selected mission indices for sake of
- * displaying their trajectories.
- */
-export const getSelectedMissionIndicesForTrajectoryDisplay: AppSelector<
-  MissionIndex[]
-> = createSelector(getSelectedMissionSlotIds, (selectedMissionSlotIds) =>
-  selectedMissionSlotIds.length <= 5
-    ? selectedMissionSlotIds.map(Number)
-    : EMPTY_ARRAY
-);
-
-/**
  * Returns a list of all the UAV IDs that participate in the mission, without
  * the null entries, sorted in ascending order by the UAV IDs.
  *
@@ -376,108 +332,6 @@ export const getGeofenceActionWithValidation: AppSelector<GeofenceAction> =
 export const getGeofencePolygonId: AppSelector<
   MissionSliceState['geofencePolygonId']
 > = (state) => state.mission.geofencePolygonId;
-
-/**
- * Gets the polygon that is to be used as a geofence.
- */
-export const getGeofencePolygon: AppSelector<
-  FeatureWithProperties | undefined
-> = createSelector(
-  getGeofencePolygonId,
-  getFeaturesById,
-  (geofencePolygonId, featuresById) =>
-    typeof geofencePolygonId === 'string'
-      ? featuresById[geofencePolygonId]
-      : undefined
-);
-
-/**
- * Gets the coordinates of the polygon that is to be used as a geofence, in
- * world coordinates, or undefined if no geofence polygon is defined.
- */
-export const getGeofencePolygonInWorldCoordinates: AppSelector<
-  LonLat[] | undefined
-> = createSelector(
-  getGeofencePolygon,
-  (geofencePolygon) => geofencePolygon?.points
-);
-
-/**
- * Returns whether a geofence is currently set by the user (either automatically)
- * or manually.
- */
-export const hasActiveGeofencePolygon: AppSelector<boolean> = createSelector(
-  getGeofencePolygonId,
-  getFeaturesById,
-  (geofencePolygonId, featuresById) =>
-    geofencePolygonId !== undefined &&
-    featuresById[geofencePolygonId] !== undefined
-);
-
-export const getExclusionZonePolygons: AppSelector<FeatureWithProperties[]> =
-  createSelector(getFeaturesInOrder, (featuresInOrder) =>
-    featuresInOrder.filter((f) => f.attributes?.['isExclusionZone'])
-  );
-
-export const getItemIndexRangeForSelectedMissionItems: AppSelector<
-  [number, number]
-> = createSelector(
-  getMissionItemIds,
-  getSelectedMissionItemIds,
-  (allIds, selectedIds) => {
-    const indices = selectedIds.map((id) => allIds.indexOf(id));
-    return [Math.min(...indices), Math.max(...indices)];
-  }
-);
-
-/**
- * Returns whether the currently selected mission items form a single,
- * uninterrupted chunk in the list of mission items.
- */
-export const areSelectedMissionItemsInOneChunk: AppSelector<boolean> =
-  createSelector(
-    getItemIndexRangeForSelectedMissionItems,
-    getSelectedMissionItemIds,
-    (indexRange, selectedIds) => {
-      const [minIndex, maxIndex] = indexRange;
-      return minIndex >= 0 && maxIndex === minIndex + selectedIds.length - 1;
-    }
-  );
-
-export const createCanMoveSelectedMissionItemsByDeltaSelector = (
-  delta: number
-): AppSelector<boolean> =>
-  createSelector(
-    getMissionItemIds,
-    areSelectedMissionItemsInOneChunk,
-    getItemIndexRangeForSelectedMissionItems,
-    (allIds, inOneChunk, indexRange) => {
-      if (!inOneChunk) {
-        return false;
-      }
-
-      const [minIndex, maxIndex] = indexRange;
-      if (delta < 0) {
-        return minIndex >= Math.abs(delta);
-      } else {
-        return maxIndex + delta < allIds.length;
-      }
-    }
-  );
-
-/**
- * Returns whether the currently selected mission items can be moved upwards
- * by one slot.
- */
-export const canMoveSelectedMissionItemsUp: AppSelector<boolean> =
-  createCanMoveSelectedMissionItemsByDeltaSelector(-1);
-
-/**
- * Returns whether the currently selected mission items can be moved downwards
- * by one slot.
- */
-export const canMoveSelectedMissionItemsDown: AppSelector<boolean> =
-  createCanMoveSelectedMissionItemsByDeltaSelector(1);
 
 /**
  * Returns whether the mission editor panel should follow the active item.
@@ -606,35 +460,6 @@ export const getConvexHullOfMissionInMapViewCoordinates: AppSelector<EasNor[]> =
         unary<LonLat, EasNor>(mapViewCoordinateFromLonLat)
       )
   );
-
-/**
- * Returns whether the convex hull of the waypoint mission (home positions and
- * mission items) is fully contained inside the geofence polygon.
- */
-export const isWaypointMissionConvexHullInsideGeofence: AppSelector<
-  boolean | undefined
-> = createSelector(
-  getConvexHullOfMissionInWorldCoordinates,
-  getGeofencePolygonInWorldCoordinates,
-  (convexHullPoints, geofencePoints) => {
-    if (
-      geofencePoints !== undefined &&
-      geofencePoints.length > 0 &&
-      convexHullPoints !== undefined &&
-      convexHullPoints.length > 0
-    ) {
-      const geofence = createGeometryFromPoints(geofencePoints);
-      const convexHull = createGeometryFromPoints(convexHullPoints);
-      return (
-        geofence.isOk() &&
-        convexHull.isOk() &&
-        turfContains(geofence.value, convexHull.value)
-      );
-    } else {
-      return false;
-    }
-  }
-);
 
 /**
  * Returns the maximum distance of any waypoint or flight area vertex in the

--- a/src/features/selection/selectors.ts
+++ b/src/features/selection/selectors.ts
@@ -1,5 +1,12 @@
 import { createSelector } from '@reduxjs/toolkit';
+import {
+  areaIdToGlobalId,
+  GROSS_CONVEX_HULL_AREA_ID,
+  homePositionIdToGlobalId,
+} from '~/model/identifiers';
 
+import { getMissionMapping } from '~/features/mission/selectors/local';
+import { hasLoadedShowFile } from '~/features/show/selectors/core';
 import type { AppSelector } from '~/store/reducers';
 import { rejectNullish } from '~/utils/arrays';
 import {
@@ -20,6 +27,20 @@ import type { SelectionGroup } from './types';
  */
 export const getSelection: AppSelector<Identifier[]> = (state) =>
   state.selection.ids;
+
+export const getVirtualSelection: AppSelector<Identifier[]> = createSelector(
+  getSelection,
+  getMissionMapping,
+  hasLoadedShowFile,
+  (selection, mapping, hasLoadedShowFile) =>
+    hasLoadedShowFile &&
+    selection.includes(areaIdToGlobalId(GROSS_CONVEX_HULL_AREA_ID))
+      ? [
+          ...selection,
+          ...mapping.map((_, i) => String(i)).map(homePositionIdToGlobalId),
+        ]
+      : selection
+);
 
 const getSelectionGroups: AppSelector<Collection<SelectionGroup>> = (state) =>
   state.selection.groups;

--- a/src/features/show/stages.ts
+++ b/src/features/show/stages.ts
@@ -11,7 +11,7 @@ import {
   hasActiveGeofencePolygon,
   hasNonemptyMappingSlot,
 } from '~/features/mission/selectors';
-import { getGeofenceStatus } from '~/features/mission/selectors-geofence-extra';
+import { getGeofenceStatus } from '~/features/mission/selectors/geofence';
 import {
   areAllPreflightChecksTicked,
   hasManualPreflightChecks,

--- a/src/model/openlayers.js
+++ b/src/model/openlayers.js
@@ -31,6 +31,7 @@ import {
   GROSS_CONVEX_HULL_AREA_ID,
   isAreaId,
   isFeatureId,
+  isHomePositionId,
   isMissionItemId,
   isOriginId,
   MAP_ORIGIN_ID,
@@ -66,7 +67,11 @@ export function isFeatureTransformable(object) {
 
   const id = object.getId();
   return (
-    isFeatureId(id) || isAreaId(id) || isOriginId(id) || isMissionItemId(id)
+    isFeatureId(id) ||
+    isAreaId(id) ||
+    isOriginId(id) ||
+    isMissionItemId(id) ||
+    isHomePositionId(id)
   );
 }
 

--- a/src/views/map/MapView.jsx
+++ b/src/views/map/MapView.jsx
@@ -38,7 +38,7 @@ import { getSelectedTool } from '~/features/map/tools';
 import { updateMapViewSettings } from '~/features/map/view';
 import { addNewMissionItem } from '~/features/mission/actions';
 import { getGeofencePolygonId } from '~/features/mission/selectors';
-import { getSelection } from '~/features/selection/selectors';
+import { getVirtualSelection } from '~/features/selection/selectors';
 import {
   addToSelection,
   removeFromSelection,
@@ -49,7 +49,12 @@ import NearestItemTooltip from '~/features/session/NearestItemTooltip';
 import { setFeatureIdForTooltip } from '~/features/session/slice';
 import { getFollowMapSelectionInUAVDetailsPanel } from '~/features/uavs/selectors';
 import mapViewManager from '~/mapViewManager';
-import { featureIdToGlobalId } from '~/model/identifiers';
+import {
+  areaIdToGlobalId,
+  featureIdToGlobalId,
+  GROSS_CONVEX_HULL_AREA_ID,
+  isHomePositionId,
+} from '~/model/identifiers';
 import {
   canLayerTriggerTooltip,
   getVisibleEditableLayers,
@@ -611,7 +616,15 @@ class MapViewPresentation extends React.Component {
       toggle: toggleInSelection,
     };
     const action = actionMapping[mode] || setSelection;
-    const ids = features ? features.map((feature) => feature.getId()) : [];
+    const rawIds = features ? features.map((feature) => feature.getId()) : [];
+
+    const ids = rawIds.some(isHomePositionId)
+      ? [
+          ...rawIds.filter((id) => !isHomePositionId(id)),
+          areaIdToGlobalId(GROSS_CONVEX_HULL_AREA_ID),
+        ]
+      : rawIds;
+
     if (action === setSelection || (ids && ids.length > 0)) {
       this.props.dispatch(action(ids));
     }
@@ -696,7 +709,7 @@ const MapView = connect(
 
     selectedFeatures: getSelectedFeatureIds(state),
     selectedTool: getSelectedTool(state),
-    selection: getSelection(state),
+    selection: getVirtualSelection(state),
 
     uavDetailsPanelFollowsSelection:
       getFollowMapSelectionInUAVDetailsPanel(state),

--- a/src/views/map/layers/mission-info.jsx
+++ b/src/views/map/layers/mission-info.jsx
@@ -41,7 +41,7 @@ import {
   getMissionItemsWithCoordinatesInOrder,
   getSelectedMissionIndicesForTrajectoryDisplay,
 } from '~/features/mission/selectors';
-import { getSelection } from '~/features/selection/selectors';
+import { getVirtualSelection } from '~/features/selection/selectors';
 import {
   getConvexHullOfShowInWorldCoordinates,
   getOutdoorShowOrientation,
@@ -638,6 +638,7 @@ const MissionInfoVectorSource = ({
           ? formatMissionId(homePositions.length - 1).length *
             TAKEOFF_LANDING_POSITION_CHARACTER_WIDTH
           : 0,
+        selection,
       }),
       landingPositionPoints(landingPositions, {
         minimumDistanceBetweenPositions: minimumDistanceBetweenLandingPositions,
@@ -752,7 +753,7 @@ export const MissionInfoLayer = connect(
       state,
       MissionItemType.RETURN_TO_HOME
     ),
-    selection: getSelection(state),
+    selection: getVirtualSelection(state),
     uavIdsForTrajectories: layer?.parameters?.showTrajectoriesOfSelection
       ? getSelectedUAVIdsForTrajectoryDisplay(state)
       : undefined,


### PR DESCRIPTION
This is a very minimal working prototype that needs more testing / consideration to decide what other special cases need to be handled.

Can be experimented with at: http://live.skybrush.donko.hu/(feat/takeoff-position-selection)

For example currently there's something weird going on if the user tries to manipulate the takeoff positions after a show is unloaded.

Also, the behavior should probably be different in the generic mission context. Maybe for the time being we should just completely disable the interactions unless we are in show mode and just deal with the rest later.