### PR TITLE
style: semi-transparent, blurred notification background

### DIFF
--- a/src/features/snackbar/Toast.tsx
+++ b/src/features/snackbar/Toast.tsx
@@ -1,10 +1,12 @@
 import Alert, { type AlertColor } from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import { styled } from '@mui/material/styles';
+import { alpha, styled } from '@mui/material/styles';
 import { type ReactNode } from 'react';
 import toast from 'react-hot-toast';
 import { useDispatch } from 'react-redux';
+
+import { isThemeDark } from '@skybrush/app-theme-mui';
 
 import Countdown from '~/components/Countdown';
 
@@ -16,14 +18,21 @@ const ToastNotificationButton = styled(Button)({
   color: 'inherit',
 });
 
-const StyledAlert = styled(Alert)({
+const StyledAlert = styled(Alert)(({ theme, severity }) => ({
   minWidth: TOAST_WIDTH,
   maxWidth: TOAST_WIDTH,
   width: TOAST_WIDTH,
+  backdropFilter: 'blur(3px)',
+  backgroundColor: alpha(
+    isThemeDark(theme)
+      ? theme.palette[severity ?? 'info'].dark
+      : theme.palette[severity ?? 'info'].light,
+    0.9
+  ),
   '> .MuiAlert-message': {
     flex: 1,
   },
-});
+}));
 
 const semanticsToSeverity: Record<MessageSemantics, AlertColor> = {
   [MessageSemantics.DEFAULT]: 'info',


### PR DESCRIPTION
Some notes:

- The transparent background unfortunately affects legibility and makes the semantic icon less pronounced. 0.9 felt okay to me.
- With dark theme, the dark color variant felt best (main is definitely a no-go), and with a dark theme, the light variant looked best.
- In the end I used `blur(3px)`, but maybe `blur(2px)` would be better if we want to have an idea of what's behind the notification. I'm curious what @vasarhelyi thinks about this. 

@ntamas If you don't like this style, feel free to simply close the PR, no comment needed :slightly_smiling_face: