### PR TITLE
Collective RTH: auto-dismiss notification when the RTH segment starts

### DIFF
--- a/src/features/show/actions.js
+++ b/src/features/show/actions.js
@@ -514,10 +514,19 @@ export const startCollectiveRTH = () => async (dispatch, getState) => {
 
   try {
     const schedule = await messageHub.execute.startCollectiveRTH();
+    const rthSegment = schedule.schedule.find(
+      (segment) => segment.type === 'rth'
+    );
     dispatch(setCollectiveRTHSchedule(schedule));
-    showSuccess(i18n.t('show.collectiveRTH.notification.success'), {
-      permanent: true,
-    });
+    showSuccess(
+      i18n.t('show.collectiveRTH.notification.success'),
+      rthSegment === undefined
+        ? undefined
+        : {
+            countdown: true,
+            timeout: rthSegment.startMs - Date.now(),
+          }
+    );
   } catch (error) {
     showError(
       error.message ?? i18n.t('show.collectiveRTH.notification.error'),


### PR DESCRIPTION
Previously the notification was permanent.

I also added a countdown to the notification, because well over 10s could pass between the trigger and the RTH segment starting (the preparation and slowdown segments come first). Without a countdown or some other visual clue, the user could easily assume it's a permanent notification. Plus it feels useful to see when the drones will actually start to return, but I may be wrong about this (the info is also visible in the RTH panel).

Alternative UI options (like adding some kind of progress bar to the notification) would also be fine. The main question for this PR in my opinion is whether the countdown makes sense or not.