### PR TITLE
Add tooltips to pro control buttons

### DIFF
--- a/src/components/PrerequisiteList.tsx
+++ b/src/components/PrerequisiteList.tsx
@@ -1,0 +1,23 @@
+import { MiniList, MiniListItem } from '@skybrush/mui-components';
+
+import type { ResolvedPrerequisite } from '~/hooks/useConstPrerequisites';
+
+type Props = {
+  prerequisites: readonly ResolvedPrerequisite[];
+};
+
+const PrerequisiteList = ({ prerequisites }: Props) => {
+  return (
+    <MiniList>
+      {prerequisites.map(({ result, message }, idx) => (
+        <MiniListItem
+          key={idx}
+          iconPreset={result ? 'success' : 'error'}
+          primaryText={message}
+        />
+      ))}
+    </MiniList>
+  );
+};
+
+export default PrerequisiteList;

--- a/src/hooks/useConstPrerequisites.tsx
+++ b/src/hooks/useConstPrerequisites.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import type { PreparedI18nKey } from '~/i18n';
+import type { AppSelector } from '~/store/reducers';
+
+export type Prerequisite = Readonly<{
+  selector: AppSelector<boolean>;
+  message: PreparedI18nKey;
+}>;
+
+export type ResolvedPrerequisite = Readonly<{
+  result: boolean;
+  message: string;
+}>;
+
+/**
+ * Hook that resolves a constant array of prerequisites.
+ *
+ * Important: the hook loops over all the items in `constPrerequisites` and
+ * resolves them with further hook calls. To avoid breaking React hook rules,
+ * the length of `constPrerequisites` must *never* change. It is also
+ * strongly recommended to make `constPrerequisites` immutable and constant.
+ */
+export const useConstPrerequisites = (
+  constPrerequisites: readonly Prerequisite[]
+) => {
+  const { t } = useTranslation();
+  const prerequisites: readonly ResolvedPrerequisite[] = constPrerequisites.map(
+    ({ selector, message }) => ({
+      result: useSelector(selector),
+      message: message(t),
+    })
+  );
+  const prerequisitesFulfilled = prerequisites.every(({ result }) => result);
+  return {
+    prerequisites,
+    prerequisitesFulfilled,
+  };
+};

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -460,7 +460,13 @@
     "collectiveRTH": "Collective RTH",
     "collectiveRTHPanelNotFound": "The Collective RTH panel was not found. Please try to open it manually from the sidebar.",
     "resume": "Resume",
-    "suspend": "Suspend"
+    "suspend": "Suspend",
+    "prerequisites": {
+      "collectiveRTHNotTriggered": "Collective RTH has not been triggered yet",
+      "hasCollectiveRTHPlan": "The show contains a collective RTH plan",
+      "proFeaturesEnabled": "Pro features are enabled on the server",
+      "supportsSuspendResumeCRTH": "The server supports the suspend, resume, and collective RTH operations"
+    }
   },
   "recalculateMappingButton": {
     "findOptimalMapping": "Find optimal mapping",

--- a/src/views/show-control/ProControlButtonGroup.tsx
+++ b/src/views/show-control/ProControlButtonGroup.tsx
@@ -1,13 +1,16 @@
 import PauseCircleOutlined from '@mui/icons-material/PauseCircleOutlined';
 import PlayCircleOutlined from '@mui/icons-material/PlayCircleOutlined';
 import Box from '@mui/material/Box';
-import { makeStyles } from '@skybrush/app-theme-mui';
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
+import { makeStyles } from '@skybrush/app-theme-mui';
+import { Tooltip } from '@skybrush/mui-components';
+
 import ColoredButton from '~/components/ColoredButton';
 import Colors from '~/components/colors';
+import PrerequisiteList from '~/components/PrerequisiteList';
 import {
   hasLicenseWithProFeatures,
   supportsSuspendResumeCRTH,
@@ -17,11 +20,47 @@ import {
   startCollectiveRTH,
   suspendShow,
 } from '~/features/show/actions';
-import { selectIsCollectiveRTHTriggered } from '~/features/show/selectors';
+import {
+  selectCollectiveRTHPlanSummary,
+  selectIsCollectiveRTHTriggered,
+} from '~/features/show/selectors';
 import { showWarning } from '~/features/snackbar/actions';
+import {
+  useConstPrerequisites,
+  type Prerequisite,
+} from '~/hooks/useConstPrerequisites';
+import { tt } from '~/i18n';
 import HomeCircleOutlined from '~/icons/HomeCircleOutlined';
 import { type RootState } from '~/store/reducers';
 import { Workbench } from '~/workbench';
+
+const GENERAL_PREREQUISITES: readonly Prerequisite[] = Object.freeze([
+  {
+    selector: (state: RootState) => hasLicenseWithProFeatures(state) ?? false,
+    message: tt('proControlButtonGroup.prerequisites.proFeaturesEnabled'),
+  },
+  {
+    selector: supportsSuspendResumeCRTH,
+    message: tt(
+      'proControlButtonGroup.prerequisites.supportsSuspendResumeCRTH'
+    ),
+  },
+  {
+    selector: (state: RootState) => !selectIsCollectiveRTHTriggered(state),
+    message: tt(
+      'proControlButtonGroup.prerequisites.collectiveRTHNotTriggered'
+    ),
+  },
+]);
+
+const CRTH_PREREQUISITES: readonly Prerequisite[] = Object.freeze([
+  {
+    selector: (state: RootState) =>
+      selectCollectiveRTHPlanSummary(state).isValid,
+    message: tt('proControlButtonGroup.prerequisites.hasCollectiveRTHPlan'),
+  },
+  ...GENERAL_PREREQUISITES,
+]);
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -29,18 +68,16 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'row',
     flex: 1,
   },
-  button: {
+  buttonWrapper: {
+    display: 'flex',
     flex: 1,
     margin: theme.spacing(0.5),
     lineHeight: '1 !important',
   },
+  button: {
+    flex: 1,
+  },
 }));
-
-type StateProps = {
-  isCollectiveRTHTriggered: boolean;
-  proFeaturesEnabled?: boolean;
-  supportsSuspendResumeCRTH: boolean;
-};
 
 type DispatchProps = {
   resumeShow: () => void;
@@ -48,71 +85,87 @@ type DispatchProps = {
   suspendShow: () => void;
 };
 
-type Props = StateProps & DispatchProps;
+type Props = DispatchProps;
 
 const ProControlButtonGroup = (props: Props) => {
-  const {
-    isCollectiveRTHTriggered,
-    proFeaturesEnabled,
-    resumeShow,
-    startCollectiveRTH,
-    supportsSuspendResumeCRTH,
-    suspendShow,
-  } = props;
+  const { resumeShow, startCollectiveRTH, suspendShow } = props;
   const workbench = useContext(Workbench);
   const classes = useStyles();
   const { t } = useTranslation();
 
-  const actionsDisabled =
-    isCollectiveRTHTriggered ||
-    !proFeaturesEnabled ||
-    !supportsSuspendResumeCRTH;
+  const { prerequisites, prerequisitesFulfilled } = useConstPrerequisites(
+    GENERAL_PREREQUISITES
+  );
+  const {
+    prerequisites: crthPrerequisites,
+    prerequisitesFulfilled: crthPrerequisitesFulfilled,
+  } = useConstPrerequisites(CRTH_PREREQUISITES);
 
   return (
     <Box className={classes.root}>
-      <ColoredButton
-        className={classes.button}
-        color={Colors.positionHold}
-        disabled={actionsDisabled}
-        icon={<PauseCircleOutlined fontSize='inherit' />}
-        onClick={suspendShow}
+      <Tooltip
+        disabled={prerequisitesFulfilled}
+        content={<PrerequisiteList prerequisites={prerequisites} />}
       >
-        {t('proControlButtonGroup.suspend')}
-      </ColoredButton>
-      <ColoredButton
-        className={classes.button}
-        color={Colors.success}
-        disabled={actionsDisabled}
-        icon={<PlayCircleOutlined fontSize='inherit' />}
-        onClick={resumeShow}
+        <div tabIndex={0} className={classes.buttonWrapper}>
+          <ColoredButton
+            className={classes.button}
+            color={Colors.positionHold}
+            disabled={!prerequisitesFulfilled}
+            icon={<PauseCircleOutlined fontSize='inherit' />}
+            onClick={suspendShow}
+          >
+            {t('proControlButtonGroup.suspend')}
+          </ColoredButton>
+        </div>
+      </Tooltip>
+      <Tooltip
+        disabled={prerequisitesFulfilled}
+        content={<PrerequisiteList prerequisites={prerequisites} />}
       >
-        {t('proControlButtonGroup.resume')}
-      </ColoredButton>
-      <ColoredButton
-        className={classes.button}
-        color={Colors.seriousWarning}
-        disabled={actionsDisabled}
-        icon={<HomeCircleOutlined fontSize='inherit' />}
-        onClick={() => {
-          startCollectiveRTH();
-          if (!workbench.bringToFront('collectiveRTH')) {
-            showWarning(t('proControlButtonGroup.collectiveRTHPanelNotFound'));
-          }
-        }}
+        <div tabIndex={0} className={classes.buttonWrapper}>
+          <ColoredButton
+            className={classes.button}
+            color={Colors.success}
+            disabled={!prerequisitesFulfilled}
+            icon={<PlayCircleOutlined fontSize='inherit' />}
+            onClick={resumeShow}
+          >
+            {t('proControlButtonGroup.resume')}
+          </ColoredButton>
+        </div>
+      </Tooltip>
+      <Tooltip
+        disabled={crthPrerequisitesFulfilled}
+        content={<PrerequisiteList prerequisites={crthPrerequisites} />}
       >
-        {t('proControlButtonGroup.collectiveRTH')}
-      </ColoredButton>
+        <div tabIndex={0} className={classes.buttonWrapper}>
+          <ColoredButton
+            className={classes.button}
+            color={Colors.seriousWarning}
+            disabled={!crthPrerequisitesFulfilled}
+            icon={<HomeCircleOutlined fontSize='inherit' />}
+            onClick={() => {
+              startCollectiveRTH();
+              if (!workbench.bringToFront('collectiveRTH')) {
+                showWarning(
+                  t('proControlButtonGroup.collectiveRTHPanelNotFound')
+                );
+              }
+            }}
+          >
+            {t('proControlButtonGroup.collectiveRTH')}
+          </ColoredButton>
+        </div>
+      </Tooltip>
     </Box>
   );
 };
 
-const ConnectedProControlButtonGroup = connect(
-  (state: RootState) => ({
-    isCollectiveRTHTriggered: selectIsCollectiveRTHTriggered(state),
-    proFeaturesEnabled: hasLicenseWithProFeatures(state),
-    supportsSuspendResumeCRTH: supportsSuspendResumeCRTH(state),
-  }),
-  { resumeShow, startCollectiveRTH, suspendShow }
-)(ProControlButtonGroup);
+const ConnectedProControlButtonGroup = connect(null, {
+  resumeShow,
+  startCollectiveRTH,
+  suspendShow,
+})(ProControlButtonGroup);
 
 export default ConnectedProControlButtonGroup;

--- a/src/views/show-control/ShowConfiguratorButton.tsx
+++ b/src/views/show-control/ShowConfiguratorButton.tsx
@@ -3,15 +3,11 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 
-import {
-  MiniList,
-  MiniListItem,
-  StatusLight,
-  Tooltip,
-} from '@skybrush/mui-components';
+import { StatusLight, Tooltip } from '@skybrush/mui-components';
 
+import PrerequisiteList from '~/components/PrerequisiteList';
 import { Status } from '~/components/semantics';
 import { showDialog as showCollectiveRTHDialog } from '~/features/collective-rth/slice';
 import {
@@ -32,18 +28,17 @@ import {
 } from '~/features/show/selectors';
 import { getSetupStageStatuses } from '~/features/show/stages';
 import { showError } from '~/features/snackbar/actions';
-import { tt, type PreparedI18nKey } from '~/i18n';
+import {
+  useConstPrerequisites,
+  type Prerequisite,
+} from '~/hooks/useConstPrerequisites';
+import { tt } from '~/i18n';
 import HomeCircleOutlined from '~/icons/HomeCircleOutlined';
 import Pro from '~/icons/Pro';
-import type { AppSelector, RootState } from '~/store/reducers';
+import type { RootState } from '~/store/reducers';
 import { type Nullable } from '~/utils/types';
 
-const PREREQUISITES: ReadonlyArray<
-  Readonly<{
-    selector: AppSelector<boolean>;
-    message: PreparedI18nKey;
-  }>
-> = Object.freeze([
+const PREREQUISITES: readonly Prerequisite[] = Object.freeze([
   {
     selector: hasLoadedShowFile,
     message: tt('show.showConfigurator.prerequisites.loaded'),
@@ -100,16 +95,8 @@ const ShowConfiguratorButton = (props: Props) => {
   const [tooltipTriggerTarget, setTooltipTriggerTarget] =
     useState<Nullable<HTMLDivElement>>();
 
-  const evaluatedPrerequisites = PREREQUISITES.map(({ selector, message }) => ({
-    // NOTE: The `PREREQUISITES` list being readonly and frozen ensures that the
-    //       `useSelector` hook will always be called the same number of times.
-    result: useSelector(selector),
-    message: message(t),
-  }));
-
-  const prerequisitesFulfilled = evaluatedPrerequisites.every(
-    ({ result }) => result
-  );
+  const { prerequisites, prerequisitesFulfilled } =
+    useConstPrerequisites(PREREQUISITES);
 
   const openWithShow = useCallback(() => {
     if (show) {
@@ -118,22 +105,6 @@ const ShowConfiguratorButton = (props: Props) => {
       showError(t('show.showConfigurator.noShowData'));
     }
   }, [show, showDialogAndClearUndoHistory, t]);
-
-  const tooltipContent = (
-    <MiniList>
-      {evaluatedPrerequisites.map(({ result, message }, idx) => (
-        <MiniListItem
-          key={idx}
-          iconPreset={
-            result
-              ? 'success'
-              : 'disconnected' /* TODO: use 'error' when we migrated to mui */
-          }
-          primaryText={message}
-        />
-      ))}
-    </MiniList>
-  );
 
   const tooltipVisible = status !== Status.OFF && !prerequisitesFulfilled;
   const disabled = status === Status.OFF || !prerequisitesFulfilled;
@@ -145,7 +116,7 @@ const ShowConfiguratorButton = (props: Props) => {
         <ListItemText
           primary={
             <Tooltip
-              content={tooltipContent}
+              content={<PrerequisiteList prerequisites={prerequisites} />}
               disabled={!tooltipVisible}
               maxWidth={500}
               placement='left'


### PR DESCRIPTION
Closes #144

I also created a hook and a component for resolving and showing prerequisite lists and fixed the `iconPreset` TODO from Tamás.

I tried to emphasize how to use the new hook safely (to avoid breaking React hook rules), although I don't think anyone would use it differently.

@vasarhelyi Feel free to update the translations as you see fit. Try not to make them longer, I saw issues with the text overflowing the tooltip. It could be fixed in `MiniListItem` if I'm not mistaken, but it wasn't necessary right now.