### PR TITLE
Convert UploadStatusPill to TS

### DIFF
--- a/src/features/upload/UploadStatusPill.tsx
+++ b/src/features/upload/UploadStatusPill.tsx
@@ -1,13 +1,13 @@
 import Box from '@mui/material/Box';
 import clsx from 'clsx';
-import isNil from 'lodash-es/isNil';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { makeStyles } from '@skybrush/app-theme-mui';
 import { StatusPill, Tooltip } from '@skybrush/mui-components';
 
 import { Status } from '~/components/semantics';
+import type { RootState } from '~/store/reducers';
+import type { Identifier } from '~/utils/collections';
 
 import { toggleUavInWaitingQueue } from './actions';
 import {
@@ -32,26 +32,54 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+type UploadStatus = {
+  hollow?: boolean;
+  status: Status;
+  message?: string;
+};
+
 /**
  * Dummy status selector for slots that do not have a corresponding UAV.
  */
-const uploadStatusSelectorForNil = () => ({ hollow: true, status: Status.OFF });
+const uploadStatusSelectorForNil = (): UploadStatus => ({
+  hollow: true,
+  status: Status.OFF,
+});
 
 /**
  * Selector factory that takes a UAV ID and returns a selector instance that
  * takes the Redux store and returns the upload status code of the given UAV.
  */
-const makeUploadStatusSelectorForUavId = (uavId) =>
-  isNil(uavId)
+const makeUploadStatusSelectorForUavId = (uavId?: Identifier) =>
+  uavId === undefined
     ? uploadStatusSelectorForNil
-    : (state) => ({
-        status: getUploadStatusCodeMapping(state)[uavId] || Status.OFF,
-        message: getUploadErrorMessageMapping(state)[uavId] || '',
+    : (state: RootState): UploadStatus => ({
+        status: getUploadStatusCodeMapping(state)[uavId] ?? Status.OFF,
+        message: getUploadErrorMessageMapping(state)[uavId] ?? '',
       });
 
-const UploadStatusPill = ({ children, message, onClick, uavId, ...rest }) => {
+type StateProps = UploadStatus;
+
+type DispatchProps = {
+  onClick?: (uavId: Identifier) => void;
+};
+
+type OwnProps = {
+  children?: React.ReactNode;
+  uavId?: Identifier;
+};
+
+type UploadStatusPillProps = OwnProps & StateProps & DispatchProps;
+
+const UploadStatusPill = ({
+  children,
+  message,
+  onClick,
+  uavId,
+  ...rest
+}: UploadStatusPillProps) => {
   const classes = useStyles();
-  const clickHandler = onClick && uavId ? () => onClick(uavId) : null;
+  const clickHandler = onClick && uavId ? () => onClick(uavId) : undefined;
   const boxedPill = (
     <Box
       className={clsx(classes.root, clickHandler && classes.selectable)}
@@ -64,16 +92,10 @@ const UploadStatusPill = ({ children, message, onClick, uavId, ...rest }) => {
   return message ? <Tooltip content={message}>{boxedPill}</Tooltip> : boxedPill;
 };
 
-UploadStatusPill.propTypes = {
-  children: PropTypes.node,
-  message: PropTypes.string,
-  onClick: PropTypes.func,
-  uavId: PropTypes.string,
-};
-
 export default connect(
   // mapStateToProps
-  (_state, { uavId }) => makeUploadStatusSelectorForUavId(uavId),
+  (state: RootState, ownProps: OwnProps) =>
+    makeUploadStatusSelectorForUavId(ownProps.uavId)(state),
   // mapDispatchToProps
   {
     onClick: toggleUavInWaitingQueue,

--- a/src/features/upload/selectors.ts
+++ b/src/features/upload/selectors.ts
@@ -237,7 +237,7 @@ export const getObjectIdsCompatibleWithSelectedJobInUploadDialog = (
  */
 export const getUploadErrorMessageMapping = (
   state: RootState
-): Record<UAV['id'], unknown> => state.upload.errors;
+): Record<UAV['id'], string> => state.upload.errors;
 
 /**
  * Returns an object that counts how many drones are currently in the

--- a/src/features/upload/slice.ts
+++ b/src/features/upload/slice.ts
@@ -59,7 +59,7 @@ export type UploadSliceState = {
   // is updated in features/upload/utils.js
 
   /** Errors corresponding to the individual UAVs in the current upload job */
-  errors: Record<UAV['id'], unknown>;
+  errors: Record<UAV['id'], string>;
 
   /** Progress information corresponding to the individual UAVs in the
    * current upload job.

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -459,14 +459,14 @@
   "proControlButtonGroup": {
     "collectiveRTH": "Collective RTH",
     "collectiveRTHPanelNotFound": "The Collective RTH panel was not found. Please try to open it manually from the sidebar.",
-    "resume": "Resume",
-    "suspend": "Suspend",
     "prerequisites": {
       "collectiveRTHNotTriggered": "Collective RTH has not been triggered yet",
       "hasCollectiveRTHPlan": "The show contains a collective RTH plan",
       "proFeaturesEnabled": "Pro features are enabled on the server",
       "supportsSuspendResumeCRTH": "The server supports the suspend, resume, and collective RTH operations"
-    }
+    },
+    "resume": "Resume",
+    "suspend": "Suspend"
   },
   "recalculateMappingButton": {
     "findOptimalMapping": "Find optimal mapping",


### PR DESCRIPTION
For some reason values in the `errors` state were typed as `unknown`, but it seems to me we only ever put strings there. I changed that to `string` mainly to avoid linter complaints about `String(unknown)` (object to string) conversions.