### PR TITLE
Remove arrify dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "@turf/helpers": "^7.3.1",
         "aframe": "^1.7.1",
         "aframe-environment-component": "^1.5.0",
-        "arrify": "^3.0.0",
         "autosuggest-highlight": "^3.3.2",
         "buffer": "^6.0.3",
         "chart.js": "^3.8.0",
@@ -6557,18 +6556,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-3.0.0.tgz",
-      "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/arrive": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/arrive/-/arrive-2.5.2.tgz",
@@ -9855,7 +9842,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -19503,7 +19489,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@turf/helpers": "^7.3.1",
     "aframe": "^1.7.1",
     "aframe-environment-component": "^1.5.0",
-    "arrify": "^3.0.0",
     "autosuggest-highlight": "^3.3.2",
     "buffer": "^6.0.3",
     "chart.js": "^3.8.0",

--- a/src/features/upload/utils.ts
+++ b/src/features/upload/utils.ts
@@ -1,12 +1,11 @@
-import arrify from 'arrify';
-import isNil from 'lodash-es/isNil';
-import pull from 'lodash-es/pull';
-import without from 'lodash-es/without';
 import {
   type CaseReducer,
   type Draft,
   type PayloadAction,
 } from '@reduxjs/toolkit';
+import isNil from 'lodash-es/isNil';
+import pull from 'lodash-es/pull';
+import without from 'lodash-es/without';
 
 import type UAV from '~/model/uav';
 import { deleteItemById } from '~/utils/collections';
@@ -84,7 +83,9 @@ export const ensureItemsInQueue = ({
   );
 
   return (state, action) => {
-    const uavIds = arrify(action.payload);
+    const uavIds = Array.isArray(action.payload)
+      ? action.payload
+      : [action.payload];
     const targetQueue = target ? state.queues[target] : undefined;
 
     for (const queueName of allOtherQueues) {
@@ -134,7 +135,9 @@ export const moveItemsBetweenQueues =
     PayloadAction<UAV['id'] | Array<UAV['id']>>
   > =>
   (state, action) => {
-    const uavIds = arrify(action.payload);
+    const uavIds = Array.isArray(action.payload)
+      ? action.payload
+      : [action.payload];
     const sourceQueue = state.queues[source];
     const targetQueue = target ? state.queues[target] : undefined;
 

--- a/src/flockwave/builders.ts
+++ b/src/flockwave/builders.ts
@@ -9,8 +9,6 @@ import type {
   Request_PRMSETMANY,
 } from '@skybrush/flockwave-spec';
 
-import arrify from 'arrify';
-
 /**
  * @file Builder functions for commonly used Flockwave messages.
  *
@@ -30,7 +28,7 @@ export function createCancellationRequest(
 ): Request_ASYNCCANCEL {
   return {
     type: 'ASYNC-CANCEL',
-    ids: arrify(receiptIds),
+    ids: Array.isArray(receiptIds) ? receiptIds : [receiptIds],
   };
 }
 
@@ -49,7 +47,7 @@ export function createResumeRequest(
 ): Request_ASYNCRESUME {
   const result: Request_ASYNCRESUME = {
     type: 'ASYNC-RESUME',
-    ids: arrify(receiptIds),
+    ids: Array.isArray(receiptIds) ? receiptIds : [receiptIds],
   };
 
   if (values !== undefined) {
@@ -113,7 +111,7 @@ export function createFirmwareUploadRequest(
 ): Request_FWUPLOAD {
   return {
     type: 'FW-UPLOAD',
-    ids: arrify(objectIds),
+    ids: Array.isArray(objectIds) ? objectIds : [objectIds],
     target: String(target),
     blob,
   };
@@ -134,7 +132,7 @@ export function createParameterSettingRequest(
 ): Request_PRMSET {
   return {
     type: 'PRM-SET',
-    ids: arrify(uavIds),
+    ids: Array.isArray(uavIds) ? uavIds : [uavIds],
     name: String(name),
     value,
   };
@@ -153,7 +151,7 @@ export function createBulkParameterUploadRequest(
 ): Request_PRMSETMANY {
   return {
     type: 'PRM-SET-MANY',
-    ids: arrify(uavIds),
+    ids: Array.isArray(uavIds) ? uavIds : [uavIds],
     parameters,
   };
 }


### PR DESCRIPTION
Notes:

`arrify` converts `undefined` and `null` to an empty array, and it can also handle iterators. As far as I could tell, none of those cases are relevant in Live.

Changed functions are all in TypeScript and are only called from TypeScript, so I think we can safely assume they are used correctly in the codebase. If you want to keep `undefined`, `null`, and iterator handling, I can replace the dependency with an equivalent TS implementation.