### PR TITLE
Fix/trim commands from string

### DIFF
--- a/src/flockwave/messages.ts
+++ b/src/flockwave/messages.ts
@@ -63,7 +63,8 @@ export function parseCommandFromString(string: string): {
   args: string[];
   kwds: Record<string, unknown>;
 } {
-  const parts = string.trim().length > 0 ? string.trim().split(/\s+/) : [''];
+  string = string.trim();
+  const parts = string.length > 0 ? string.split(/\s+/) : [''];
   return {
     command: parts[0] ?? '',
     args: parts.slice(1),


### PR DESCRIPTION
This mini-PR trims command strings entered in the Properties->Messages panel before processing. I also removed checking of undefined strings as type indicated valid string. Hope it is OK.