### PR TITLE
Update upload statuses after relevant state changes

### DIFF
--- a/src/features/mission/actions/actions.js
+++ b/src/features/mission/actions/actions.js
@@ -64,13 +64,13 @@ import { chooseUniqueId } from '~/utils/naming';
 import { createAsyncAction } from '~/utils/redux';
 import workers from '~/workers';
 
-import { JOB_TYPE } from './constants';
+import { JOB_TYPE } from '../constants';
 import {
   contextVolatilities,
   ContextVolatility,
   getParametersFromContext,
   ParameterUIContext,
-} from './parameter-context';
+} from '../parameter-context';
 import {
   createCanMoveSelectedMissionItemsByDeltaSelector,
   getEmptyMappingSlotIndices,
@@ -89,19 +89,15 @@ import {
   getMissionPlannerDialogUserParameters,
   getSelectedMissionItemIds,
   shouldMissionPlannerDialogApplyGeofence,
-} from './selectors';
+} from '../selectors';
 import {
   _setMissionItemsFromValidatedArray,
   addMissionItem,
-  clearMapping,
   closeMissionPlannerDialog,
   moveMissionItem,
   removeMissionItemsByIds,
-  removeUAVsFromMapping,
-  replaceMapping,
   setLastClearedMissionData,
   setLastSuccessfulPlannerInvocationParameters,
-  setMappingLength,
   setMissionName,
   setMissionPlannerDialogSelectedType,
   setMissionPlannerDialogUserParameters,
@@ -110,8 +106,14 @@ import {
   updateCurrentMissionItemRatio,
   updateHomePositions,
   updateMissionItemParameters,
-} from './slice';
-import { getMissionItemUploadJobPayload } from './upload';
+} from '../slice';
+import { getMissionItemUploadJobPayload } from '../upload';
+import {
+  clearMapping,
+  removeUAVsFromMapping,
+  replaceMapping,
+  setMappingLength,
+} from './ts-actions';
 
 /**
  * Internal action that finds an optimal assignment between two point sets

--- a/src/features/mission/actions/index.ts
+++ b/src/features/mission/actions/index.ts
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './ts-actions';

--- a/src/features/mission/actions/ts-actions.ts
+++ b/src/features/mission/actions/ts-actions.ts
@@ -70,11 +70,17 @@ export const commitMappingEditorSessionAtCurrentSlot =
     const mappingState = getMissionMapping(state);
     const index = getIndexOfMappingSlotBeingEdited(state);
 
-    if (index >= 0 && index < mappingState.length) {
+    if (index < 0 || index >= mappingState.length) {
+      dispatch(updateEditedMappingIndex(continuation));
+      return;
+    }
+
+    const oldValue = mappingState[index];
+    const existingIndex =
+      validatedValue === null ? -1 : mappingState.indexOf(validatedValue);
+
+    if (index !== existingIndex || validatedValue !== oldValue) {
       const newMapping = [...mappingState];
-      const oldValue = newMapping[index];
-      const existingIndex =
-        validatedValue === null ? -1 : newMapping.indexOf(validatedValue);
 
       // Collect affected UAV IDs (non-null values)
       const affectedUavIds: Identifier[] = [];

--- a/src/features/mission/actions/ts-actions.ts
+++ b/src/features/mission/actions/ts-actions.ts
@@ -1,0 +1,186 @@
+import isNil from 'lodash-es/isNil';
+
+import type { MissionIndex } from '~/model/missions';
+import type { AppThunk } from '~/store/reducers';
+import type { Identifier } from '~/utils/collections';
+import type { Nullable } from '~/utils/types';
+
+import {
+  getIndexOfMappingSlotBeingEdited,
+  getMissionMapping,
+} from '../selectors';
+import {
+  _setMapping,
+  _setMappingLength,
+  notifyUAVsInMissionMappingChanged,
+  updateEditedMappingIndex,
+} from '../slice';
+import { type MissionMappingEditorContinuation } from '../utils';
+
+export const adjustMissionMapping =
+  ({ uavId, to }: { uavId: Identifier; to: MissionIndex | null }): AppThunk =>
+  (dispatch, getState) => {
+    const affectedUavIds: Identifier[] = [uavId];
+    const mapping = [...getMissionMapping(getState())];
+    const from = mapping.indexOf(uavId);
+    const uavIdToReplace = isNil(to) ? null : mapping[to];
+
+    if (!isNil(uavIdToReplace)) {
+      affectedUavIds.push(uavIdToReplace);
+    }
+
+    if (from >= 0) {
+      mapping[from] = uavIdToReplace ?? null;
+    }
+
+    if (!isNil(to)) {
+      mapping[to] = uavId;
+    }
+
+    dispatch(_setMapping(mapping));
+    dispatch(notifyUAVsInMissionMappingChanged(affectedUavIds));
+  };
+
+/**
+ * Clears the entire mission mapping.
+ */
+export const clearMapping = (): AppThunk => (dispatch, getState) => {
+  const length = getMissionMapping(getState()).length;
+  dispatch(_setMapping(Array.from({ length }, () => null)));
+  // The entire mapping is invalid.
+  dispatch(notifyUAVsInMissionMappingChanged(undefined));
+};
+
+/**
+ * Commits the new value in the mapping editor to the current slot being
+ * edited, and optionally continues with the next slot.
+ */
+export const commitMappingEditorSessionAtCurrentSlot =
+  ({
+    continuation,
+    value,
+  }: {
+    continuation: MissionMappingEditorContinuation;
+    value: string;
+  }): AppThunk =>
+  (dispatch, getState) => {
+    const validatedValue =
+      typeof value === 'string' && value.trim().length > 0 ? value : null;
+    const state = getState();
+    const mappingState = getMissionMapping(state);
+    const index = getIndexOfMappingSlotBeingEdited(state);
+
+    if (index >= 0 && index < mappingState.length) {
+      const newMapping = [...mappingState];
+      const oldValue = newMapping[index];
+      const existingIndex =
+        validatedValue === null ? -1 : newMapping.indexOf(validatedValue);
+
+      // Collect affected UAV IDs (non-null values)
+      const affectedUavIds: Identifier[] = [];
+      if (!isNil(oldValue)) {
+        affectedUavIds.push(oldValue);
+      }
+      if (!isNil(validatedValue)) {
+        affectedUavIds.push(validatedValue);
+      }
+
+      // Prevent duplicates: if the value being entered already exists
+      // elsewhere in the mapping, swap it with the old value of the
+      // slot being edited.
+      if (existingIndex >= 0) {
+        newMapping[existingIndex] = oldValue ?? null;
+      }
+
+      newMapping[index] = validatedValue;
+      dispatch(_setMapping(newMapping));
+      if (affectedUavIds.length > 0) {
+        dispatch(notifyUAVsInMissionMappingChanged(affectedUavIds));
+      }
+    }
+
+    dispatch(updateEditedMappingIndex(continuation));
+  };
+
+/**
+ * Removes some UAVs from the mission mapping.
+ */
+export const removeUAVsFromMapping =
+  (uavIds: Identifier[]): AppThunk =>
+  (dispatch, getState) => {
+    const mapping = [...getMissionMapping(getState())];
+    const affectedUavIds: Identifier[] = [];
+
+    for (const uavId of uavIds) {
+      const index = mapping.indexOf(uavId);
+      if (index >= 0) {
+        affectedUavIds.push(uavId);
+        mapping[index] = null;
+      }
+    }
+
+    dispatch(_setMapping(mapping));
+    if (affectedUavIds.length > 0) {
+      dispatch(notifyUAVsInMissionMappingChanged(affectedUavIds));
+    }
+  };
+
+/**
+ * Replaces the entire mission mapping with a new one.
+ */
+export const replaceMapping =
+  (newMapping: Array<Nullable<Identifier>>): AppThunk =>
+  (dispatch, getState) => {
+    if (!Array.isArray(newMapping)) {
+      throw new TypeError('New mapping must be an array');
+    }
+
+    const currentMapping = getMissionMapping(getState());
+    const currentLength = currentMapping.length;
+    if (newMapping.length !== currentLength) {
+      throw new Error('Cannot change mapping length with replaceMapping()');
+    }
+
+    // Collect affected UAV IDs (non-null values from both current and new mapping)
+    const affectedUavIds: Identifier[] = [
+      ...currentMapping.filter((id): id is Identifier => !isNil(id)),
+      ...newMapping.filter((id): id is Identifier => !isNil(id)),
+    ];
+
+    dispatch(_setMapping(newMapping));
+    if (affectedUavIds.length > 0) {
+      dispatch(notifyUAVsInMissionMappingChanged(affectedUavIds));
+    }
+  };
+
+/**
+ * Sets the length of the mapping. When the new length is smaller than the
+ * old length, the mapping will be truncated from the end. When the new
+ * length is larger than the old length, empty slots will be added to the
+ * end of the mapping.
+ */
+export const setMappingLength =
+  (length: string | number): AppThunk =>
+  (dispatch, getState) => {
+    const currentMapping = getMissionMapping(getState());
+    const desiredLength =
+      typeof length === 'string' ? Number.parseInt(length, 10) : length;
+
+    let affectedUavIds: Identifier[] | undefined;
+    if (
+      !Number.isNaN(desiredLength) &&
+      desiredLength >= 0 &&
+      desiredLength < currentMapping.length
+    ) {
+      // Collect affected UAV IDs (non-null values in truncated range)
+      affectedUavIds = currentMapping
+        .slice(desiredLength)
+        .filter((id): id is Identifier => !isNil(id));
+    }
+
+    dispatch(_setMappingLength(length));
+
+    if (affectedUavIds !== undefined && affectedUavIds.length > 0) {
+      dispatch(notifyUAVsInMissionMappingChanged(affectedUavIds));
+    }
+  };

--- a/src/features/mission/slice.ts
+++ b/src/features/mission/slice.ts
@@ -6,7 +6,6 @@
  * in the mission.
  */
 
-import isNil from 'lodash-es/isNil';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { MAX_DRONE_COUNT } from '@skybrush/show-format';
 
@@ -19,12 +18,12 @@ import {
   type MissionItem,
   MissionType,
 } from '~/model/missions';
-import type UAV from '~/model/uav';
 import {
-  type Collection,
   addItemAt,
   addItemToBack,
+  type Collection,
   deleteItemsByIds,
+  type Identifier,
 } from '~/utils/collections';
 import { noPayload } from '~/utils/redux';
 import { type Nullable } from '~/utils/types';
@@ -59,7 +58,7 @@ export type MissionSliceState = {
    *
    * @see The `NOTE` at `MissionSliceState`
    */
-  mapping: Array<Nullable<UAV['id']>>;
+  mapping: Array<Nullable<Identifier>>;
 
   /**
    * Stores the desired home position (starting point) of each drone
@@ -231,26 +230,6 @@ const { actions, reducer } = createSlice({
       }
     },
 
-    adjustMissionMapping(
-      state,
-      action: PayloadAction<{
-        uavId: UAV['id'];
-        to: Nullable<MissionIndex>;
-      }>
-    ) {
-      const { uavId, to } = action.payload;
-      const from = state.mapping.indexOf(uavId);
-      const uavIdToReplace = isNil(to) ? null : state.mapping[to];
-
-      if (from >= 0) {
-        state.mapping[from] = uavIdToReplace ?? null;
-      }
-
-      if (!isNil(to)) {
-        state.mapping[to] = uavId;
-      }
-    },
-
     /**
      * Notifies the state store that we have started calculating, updating or
      * augmenting the current mission mapping.
@@ -293,23 +272,6 @@ const { actions, reducer } = createSlice({
     }),
 
     /**
-     * Clears the entire mission mapping.
-     */
-    clearMapping(state) {
-      state.mapping = Array.from({ length: state.mapping.length }, () => null);
-    },
-
-    /**
-     * Clears a single slot in the mission mapping.
-     */
-    clearMappingSlot(state, action: PayloadAction<MissionIndex>) {
-      const index = action.payload;
-      if (index >= 0 && index < state.mapping.length) {
-        state.mapping[index] = null;
-      }
-    },
-
-    /**
      * Closes the mission planner dialog.
      */
     closeMissionPlannerDialog: noPayload<MissionSliceState>((state) => {
@@ -323,43 +285,6 @@ const { actions, reducer } = createSlice({
       state.mappingEditor.enabled = false;
       state.mappingEditor.indexBeingEdited = -1;
     }),
-
-    /**
-     * Commits the new value in the mapping editor to the current slot being
-     * edited, and optionally continues with the next slot.
-     */
-    commitMappingEditorSessionAtCurrentSlot(
-      state,
-      action: PayloadAction<{
-        continuation: MissionMappingEditorContinuation;
-        value: string;
-      }>
-    ) {
-      const { continuation, value } = action.payload;
-      const validatedValue =
-        typeof value === 'string' && value.trim().length > 0 ? value : null;
-      const index = state.mappingEditor.indexBeingEdited;
-
-      if (index >= 0 && index < state.mapping.length) {
-        const oldValue = state.mapping[index];
-        const existingIndex =
-          validatedValue === null ? -1 : state.mapping.indexOf(validatedValue);
-
-        // Prevent duplicates: if the value being entered already exists
-        // elsewhere in the mapping, swap it with the old value of the
-        // slot being edited.
-        if (existingIndex >= 0) {
-          state.mapping[existingIndex] = oldValue ?? null;
-        }
-
-        state.mapping[index] = validatedValue;
-      }
-
-      state.mappingEditor.indexBeingEdited = getNewEditIndex(
-        state,
-        continuation
-      );
-    },
 
     moveMissionItem: {
       prepare: (oldIndex: number, newIndex: number) => ({
@@ -389,35 +314,6 @@ const { actions, reducer } = createSlice({
       action: PayloadAction<Array<MissionItem['id']>>
     ) {
       deleteItemsByIds(state.items, action.payload);
-    },
-
-    /**
-     * Removes some UAVs from the mission mapping.
-     */
-    removeUAVsFromMapping(state, action: PayloadAction<Array<UAV['id']>>) {
-      for (const uavId of action.payload) {
-        const index = state.mapping.indexOf(uavId);
-        if (index >= 0) {
-          state.mapping[index] = null;
-        }
-      }
-    },
-
-    /**
-     * Replaces the entire mission mapping with a new one.
-     */
-    replaceMapping(state, action: PayloadAction<Array<Nullable<UAV['id']>>>) {
-      const newMapping = action.payload;
-
-      if (!Array.isArray(newMapping)) {
-        throw new TypeError('New mapping must be an array');
-      }
-
-      if (newMapping.length !== state.mapping.length) {
-        throw new Error('Cannot change mapping length with replaceMapping()');
-      }
-
-      state.mapping = newMapping;
     },
 
     /**
@@ -453,12 +349,24 @@ const { actions, reducer } = createSlice({
     },
 
     /**
+     * Updates the mission mapping to the given value.
+     *
+     * The mapping must always be edited through actions that first execute
+     * this reducer, and then `notifyUAVsInMissionMappingChanged()`.
+     */
+    _setMapping(state, action: PayloadAction<Array<Nullable<Identifier>>>) {
+      state.mapping = action.payload;
+    },
+
+    /**
      * Sets the length of the mapping. When the new length is smaller than the
      * old length, the mapping will be truncated from the end. When the new
      * length is larger than the old length, empty slots will be added to the
      * end of the mapping.
+     *
+     * This reducer must always be used through the corresponding action!
      */
-    setMappingLength(state, action: PayloadAction<string | number>) {
+    _setMappingLength(state, action: PayloadAction<string | number>) {
       // TODO: Remove the string case.
       const desiredLength =
         typeof action.payload === 'string'
@@ -631,6 +539,20 @@ const { actions, reducer } = createSlice({
     },
 
     /**
+     * Updates the index being edited in the mapping editor based on
+     * requested continuation type.
+     */
+    updateEditedMappingIndex(
+      state,
+      action: PayloadAction<MissionMappingEditorContinuation>
+    ) {
+      state.mappingEditor.indexBeingEdited = getNewEditIndex(
+        state,
+        action.payload
+      );
+    },
+
+    /**
      * Updates the home positions of all the drones in the mission.
      */
     updateHomePositions(
@@ -680,6 +602,25 @@ const { actions, reducer } = createSlice({
     },
 
     /**
+     * Reducer whose only role is to let other slices register extra
+     * reducers to run after the mission mapping has changed.
+     *
+     * This reducer must be called by every action that changes the
+     * mission mapping, after the mission mapping has been updated.
+     *
+     * The payload can be an array of affected UAV IDs, or undefined
+     * if the entire mission mapping became invalid.
+     *
+     * It is NOT guaranteed that the IDs in the array are unique!
+     */
+    notifyUAVsInMissionMappingChanged(
+      _state,
+      _action: PayloadAction<Identifier[] | undefined>
+    ) {
+      // Noop
+    },
+
+    /**
      * Updates the takeoff headings of all the drones in the mission.
      */
     updateTakeoffHeadings(
@@ -711,26 +652,22 @@ const { actions, reducer } = createSlice({
 });
 
 export const {
+  _setMappingLength,
   addMissionItem,
-  adjustMissionMapping,
   cancelMappingEditorSessionAtCurrentSlot,
   clearGeofencePolygonId,
-  clearMapping,
-  clearMappingSlot,
   closeMissionPlannerDialog,
-  commitMappingEditorSessionAtCurrentSlot,
   finishMappingEditorSession,
   moveMissionItem,
+  notifyUAVsInMissionMappingChanged,
   removeMissionItemsByIds,
-  removeUAVsFromMapping,
-  replaceMapping,
   setCommandsAreBroadcast,
+  _setMapping,
   setEditorPanelFollowScroll,
   setGeofenceAction,
   setGeofencePolygonId,
   setLastClearedMissionData,
   setLastSuccessfulPlannerInvocationParameters,
-  setMappingLength,
   setMissionName,
   setMissionPlannerDialogApplyGeofence,
   setMissionPlannerDialogContextParameters,
@@ -743,6 +680,7 @@ export const {
   togglePreferredChannel,
   updateCurrentMissionItemId,
   updateCurrentMissionItemRatio,
+  updateEditedMappingIndex,
   updateHomePositions,
   updateLandingPositions,
   updateMissionItemParameters,

--- a/src/features/show/actions.js
+++ b/src/features/show/actions.js
@@ -11,9 +11,9 @@ import { loadShowSpecificationAndZip as processFile } from '@skybrush/show-forma
 
 import { getFeaturesInOrder } from '~/features/map-features/selectors';
 import { removeFeaturesByIds } from '~/features/map-features/slice';
+import { setMappingLength } from '~/features/mission/actions';
 import {
   setCommandsAreBroadcast,
-  setMappingLength,
   setMissionType,
   updateHomePositions,
   updateLandingPositions,

--- a/src/features/upload/slice.ts
+++ b/src/features/upload/slice.ts
@@ -5,12 +5,21 @@
 
 import { type Action, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-import { notifyUAVsInMissionMappingChanged } from '~/features/mission/slice';
+import {
+  clearGeofencePolygonId,
+  notifyUAVsInMissionMappingChanged,
+  setGeofenceAction,
+  setGeofencePolygonId,
+} from '~/features/mission/slice';
 import { JOB_TYPE as PARAMETER_UPLOAD_JOB_TYPE } from '~/features/parameters/constants';
 import {
   removeParameterFromManifest,
   updateParametersInManifest,
 } from '~/features/parameters/slice';
+import {
+  updateGeofenceSettings,
+  updateSafetySettings,
+} from '~/features/safety/slice';
 import { SHOW_UPLOAD_JOB } from '~/features/show/constants';
 import { _clearLoadedShow } from '~/features/show/slice';
 import type { Identifier } from '~/utils/collections';
@@ -143,6 +152,21 @@ const initialState: UploadSliceState = {
     flashFailed: false,
     restrictToGlobalSelection: false,
   },
+};
+
+const historyCleaningActionMatchersByJobType = {
+  [SHOW_UPLOAD_JOB.type]: new Set<string>([
+    _clearLoadedShow.type,
+    clearGeofencePolygonId.type,
+    setGeofenceAction.type,
+    setGeofencePolygonId.type,
+    updateGeofenceSettings.type,
+    updateSafetySettings.type,
+  ]),
+  [PARAMETER_UPLOAD_JOB_TYPE]: new Set<string>([
+    removeParameterFromManifest.type,
+    updateParametersInManifest.type,
+  ]),
 };
 
 const { actions, reducer } = createSlice({
@@ -416,10 +440,6 @@ const { actions, reducer } = createSlice({
   },
 
   extraReducers(builder) {
-    builder.addCase(_clearLoadedShow, (state) => {
-      clearUploadHistoryForJobTypeHelper(state, SHOW_UPLOAD_JOB.type);
-    });
-
     builder.addCase(notifyUAVsInMissionMappingChanged, (state, action) => {
       if (state.history[SHOW_UPLOAD_JOB.type] === undefined) {
         // No history, nothing to do. We must avoid creating a new history
@@ -449,13 +469,27 @@ const { actions, reducer } = createSlice({
       });
     });
 
-    builder.addCase(removeParameterFromManifest, (state) => {
-      clearUploadHistoryForJobTypeHelper(state, PARAMETER_UPLOAD_JOB_TYPE);
-    });
+    builder.addMatcher(
+      // Clear show upload history
+      (action: Action) =>
+        historyCleaningActionMatchersByJobType[SHOW_UPLOAD_JOB.type].has(
+          action.type
+        ),
+      (state) => {
+        clearUploadHistoryForJobTypeHelper(state, SHOW_UPLOAD_JOB.type);
+      }
+    );
 
-    builder.addCase(updateParametersInManifest, (state) => {
-      clearUploadHistoryForJobTypeHelper(state, PARAMETER_UPLOAD_JOB_TYPE);
-    });
+    builder.addMatcher(
+      // Clear parameter upload history
+      (action: Action) =>
+        historyCleaningActionMatchersByJobType[PARAMETER_UPLOAD_JOB_TYPE].has(
+          action.type
+        ),
+      (state) => {
+        clearUploadHistoryForJobTypeHelper(state, PARAMETER_UPLOAD_JOB_TYPE);
+      }
+    );
   },
 });
 

--- a/src/features/upload/slice.ts
+++ b/src/features/upload/slice.ts
@@ -6,6 +6,11 @@
 import { type Action, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 import { notifyUAVsInMissionMappingChanged } from '~/features/mission/slice';
+import { JOB_TYPE as PARAMETER_UPLOAD_JOB_TYPE } from '~/features/parameters/constants';
+import {
+  removeParameterFromManifest,
+  updateParametersInManifest,
+} from '~/features/parameters/slice';
 import { SHOW_UPLOAD_JOB } from '~/features/show/constants';
 import { _clearLoadedShow } from '~/features/show/slice';
 import type { Identifier } from '~/utils/collections';
@@ -414,6 +419,7 @@ const { actions, reducer } = createSlice({
     builder.addCase(_clearLoadedShow, (state) => {
       clearUploadHistoryForJobTypeHelper(state, SHOW_UPLOAD_JOB.type);
     });
+
     builder.addCase(notifyUAVsInMissionMappingChanged, (state, action) => {
       const uavIds = action.payload;
 
@@ -433,6 +439,14 @@ const { actions, reducer } = createSlice({
           {} as Record<string, MaybeOutdateUAVStatus>
         ),
       });
+    });
+
+    builder.addCase(removeParameterFromManifest, (state) => {
+      clearUploadHistoryForJobTypeHelper(state, PARAMETER_UPLOAD_JOB_TYPE);
+    });
+
+    builder.addCase(updateParametersInManifest, (state) => {
+      clearUploadHistoryForJobTypeHelper(state, PARAMETER_UPLOAD_JOB_TYPE);
     });
   },
 });

--- a/src/features/upload/slice.ts
+++ b/src/features/upload/slice.ts
@@ -421,6 +421,14 @@ const { actions, reducer } = createSlice({
     });
 
     builder.addCase(notifyUAVsInMissionMappingChanged, (state, action) => {
+      if (state.history[SHOW_UPLOAD_JOB.type] === undefined) {
+        // No history, nothing to do. We must avoid creating a new history
+        // item, because that would affect the result of the
+        // `makeUploadStatusSelectorForMissionMappingByJobType()`
+        // factory!!
+        return;
+      }
+
       const uavIds = action.payload;
 
       if (uavIds === undefined) {

--- a/src/features/upload/slice.ts
+++ b/src/features/upload/slice.ts
@@ -5,19 +5,25 @@
 
 import { type Action, createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
+import { notifyUAVsInMissionMappingChanged } from '~/features/mission/slice';
 import { SHOW_UPLOAD_JOB } from '~/features/show/constants';
 import { _clearLoadedShow } from '~/features/show/slice';
 import type { Identifier } from '~/utils/collections';
 import { noPayload } from '~/utils/redux';
 
-import type { HistoryItem, JobData, JobPayload } from './types';
+import type {
+  HistoryItem,
+  JobData,
+  JobPayload,
+  MaybeOutdateUAVStatus,
+} from './types';
 import {
   clearQueues,
   clearUploadHistoryForJobTypeHelper,
-  compactHistory,
   createHistoryItem,
   ensureItemsInQueue,
   moveItemsBetweenQueues,
+  pushItemToHistory,
 } from './utils';
 
 export type UploadSliceState = {
@@ -229,17 +235,15 @@ const { actions, reducer } = createSlice({
 
       // Store the data in history
       if (jobType) {
-        const historyItem = createHistoryItem(
-          cancelled ? 'cancelled' : success ? 'success' : 'error',
-          state.queues,
-          state.errors
+        pushItemToHistory(
+          state.history,
+          jobType,
+          createHistoryItem(
+            cancelled ? 'cancelled' : success ? 'success' : 'error',
+            state.queues,
+            state.errors
+          )
         );
-
-        if (!state.history[jobType]) {
-          state.history[jobType] = [];
-        }
-        state.history[jobType].push(historyItem);
-        state.history[jobType] = compactHistory(state.history[jobType]);
       }
 
       // Clear queues and show the last upload result in the dialog.
@@ -409,6 +413,26 @@ const { actions, reducer } = createSlice({
   extraReducers(builder) {
     builder.addCase(_clearLoadedShow, (state) => {
       clearUploadHistoryForJobTypeHelper(state, SHOW_UPLOAD_JOB.type);
+    });
+    builder.addCase(notifyUAVsInMissionMappingChanged, (state, action) => {
+      const uavIds = action.payload;
+
+      if (uavIds === undefined) {
+        clearUploadHistoryForJobTypeHelper(state, SHOW_UPLOAD_JOB.type);
+        return;
+      }
+
+      pushItemToHistory(state.history, SHOW_UPLOAD_JOB.type, {
+        result: 'success',
+        perUavErrors: {},
+        perUavStatuses: uavIds.reduce(
+          (res, id) => {
+            res[id] = 'outdated';
+            return res;
+          },
+          {} as Record<string, MaybeOutdateUAVStatus>
+        ),
+      });
     });
   },
 });

--- a/src/features/upload/types.ts
+++ b/src/features/upload/types.ts
@@ -17,6 +17,8 @@ export type JobData = {
 
 export type UAVStatus = 'success' | 'error';
 
+export type MaybeOutdateUAVStatus = UAVStatus | 'outdated';
+
 export type UploadJobResult = UAVStatus | 'cancelled';
 
 /**
@@ -28,6 +30,6 @@ type ErrorMessage = string;
 
 export type HistoryItem = {
   result: UploadJobResult;
-  perUavStatuses: Record<Identifier, UAVStatus>;
+  perUavStatuses: Record<Identifier, MaybeOutdateUAVStatus>;
   perUavErrors: Record<Identifier, ErrorMessage>;
 };

--- a/src/features/upload/utils.ts
+++ b/src/features/upload/utils.ts
@@ -180,7 +180,9 @@ export const moveItemsBetweenQueues =
   };
 
 /**
- * Aggregates UAV statuses from the given history items.
+ * Aggregates up to date UAV statuses from the given history items.
+ *
+ * Outdated statuses are ignored.
  */
 export function aggregateUAVStatusesFromHistory<TStatus>(
   historyItems: HistoryItem[] | undefined,
@@ -193,7 +195,11 @@ export function aggregateUAVStatusesFromHistory<TStatus>(
 
   for (const item of historyItems) {
     for (const [uavId, status] of Object.entries(item.perUavStatuses)) {
-      result[uavId] = mapStatus(status);
+      if (status === 'outdated') {
+        delete result[uavId];
+      } else {
+        result[uavId] = mapStatus(status);
+      }
     }
   }
 
@@ -277,4 +283,17 @@ export function compactHistory(
   };
 
   return [compacted, ...history.slice(mergeUntil)];
+}
+
+/**
+ * Pushes a new history item into the history of the given job type.
+ */
+export function pushItemToHistory(
+  history: Record<string, HistoryItem[]>,
+  jobType: string,
+  item: HistoryItem
+) {
+  const historyItems = history[jobType] ?? [];
+  historyItems.push(item);
+  history[jobType] = compactHistory(historyItems);
 }

--- a/src/views/uavs/MappingButtonGroup.jsx
+++ b/src/views/uavs/MappingButtonGroup.jsx
@@ -10,11 +10,9 @@ import { connect } from 'react-redux';
 import ToggleButton from '~/components/ToggleButton';
 import ToolbarDivider from '~/components/ToolbarDivider';
 import { TooltipWithContainerFromContext as Tooltip } from '~/containerContext';
+import { clearMapping } from '~/features/mission/actions';
 import { isMappingEditable } from '~/features/mission/selectors';
-import {
-  clearMapping,
-  startMappingEditorSession,
-} from '~/features/mission/slice';
+import { startMappingEditorSession } from '~/features/mission/slice';
 import {
   getUAVListLayout,
   isShowingEmptyMissionSlots,

--- a/src/views/uavs/MappingEditorToolbar.tsx
+++ b/src/views/uavs/MappingEditorToolbar.tsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import Colors from '~/components/colors';
 import {
   augmentMappingAutomaticallyFromSpareDrones,
+  clearMapping,
   exportMapping,
   generateRandomMapping,
   importMapping,
@@ -24,10 +25,7 @@ import {
   canAugmentMappingAutomaticallyFromSpareDrones,
   isMappingBeingCalculated,
 } from '~/features/mission/selectors';
-import {
-  clearMapping,
-  finishMappingEditorSession,
-} from '~/features/mission/slice';
+import { finishMappingEditorSession } from '~/features/mission/slice';
 import { isDeveloperModeEnabled } from '~/features/session/selectors';
 import useDropdown from '~/hooks/useDropdown';
 import type { RootState } from '~/store/reducers';

--- a/src/views/uavs/MappingSlotEditorForGrid.jsx
+++ b/src/views/uavs/MappingSlotEditorForGrid.jsx
@@ -7,11 +7,9 @@ import { connect } from 'react-redux';
 import { makeStyles } from '@skybrush/app-theme-mui';
 
 import Colors from '~/components/colors';
+import { commitMappingEditorSessionAtCurrentSlot } from '~/features/mission/actions';
 import { getUAVIdForMappingSlotBeingEdited } from '~/features/mission/selectors';
-import {
-  cancelMappingEditorSessionAtCurrentSlot,
-  commitMappingEditorSessionAtCurrentSlot,
-} from '~/features/mission/slice';
+import { cancelMappingEditorSessionAtCurrentSlot } from '~/features/mission/slice';
 import { shouldOptimizeUIForTouch } from '~/features/settings/selectors';
 
 const useStyles = makeStyles((theme) => ({

--- a/src/views/uavs/MappingSlotEditorForList.jsx
+++ b/src/views/uavs/MappingSlotEditorForList.jsx
@@ -7,11 +7,9 @@ import { connect } from 'react-redux';
 import { makeStyles, monospacedFont } from '@skybrush/app-theme-mui';
 
 import Colors from '~/components/colors';
+import { commitMappingEditorSessionAtCurrentSlot } from '~/features/mission/actions';
 import { getUAVIdForMappingSlotBeingEdited } from '~/features/mission/selectors';
-import {
-  cancelMappingEditorSessionAtCurrentSlot,
-  commitMappingEditorSessionAtCurrentSlot,
-} from '~/features/mission/slice';
+import { cancelMappingEditorSessionAtCurrentSlot } from '~/features/mission/slice';
 import { shouldOptimizeUIForTouch } from '~/features/settings/selectors';
 
 const WIDTH = 80;

--- a/src/views/uavs/UAVList.tsx
+++ b/src/views/uavs/UAVList.tsx
@@ -29,14 +29,12 @@ import FadeAndSlide from '~/components/transitions/FadeAndSlide';
 import DroneAvatar from '~/components/uavs/DroneAvatar';
 import DronePlaceholder from '~/components/uavs/DronePlaceholder';
 import { useKeyboardNavigation } from '~/features/hotkeys/hooks';
+import { adjustMissionMapping } from '~/features/mission/actions';
 import {
   getIndexOfMappingSlotBeingEdited,
   isMappingEditable,
 } from '~/features/mission/selectors';
-import {
-  adjustMissionMapping,
-  startMappingEditorSessionAtSlot,
-} from '~/features/mission/slice';
+import { startMappingEditorSessionAtSlot } from '~/features/mission/slice';
 import { getSelection } from '~/features/selection/selectors';
 import { setSelection } from '~/features/selection/slice';
 import {


### PR DESCRIPTION
Changes:

- Refactored the `mission` slice: replaced a number of reducers with actions and added a `notifyUAVsInMissionMappingChanged()` reducer that can be used to update other slices when the mission mapping changes.
- Introduced an `'outdated'` UAV upload status. Outdated statuses hide previous statuses in the history during status aggregation.
- Mark UAV show upload statuses as outdated when the mission mapping changes. Only the statuses of affected UAVs get outdated (except when the mapping is fully replaced, but that usually happens after the mapping is cleared if I'm not mistaken, which obviously affects every UAV).
- Delete parameter upload statuses when the parameter list changes. In this case we always delete every status, I didn't want to refactor this `parameters` slice in this PR. We can improve it in the future.