### PR TITLE
Select all UAVs with no status when clicking on the waiting button in the upload dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RTK base station coordinates can now be restored from positions stored during
   earlier surveys.
 
+- When 0, the "waiting" counter, now selects all visible UAVs that have no
+  upload status.
+
 ### Changed
 
 - Smaller headings in the Field Notes panel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RTK base station coordinates can now be restored from positions stored during
   earlier surveys.
 
-- When 0, the "waiting" counter, now selects all visible UAVs that have no
+- In the upload dialog, if there are no waiting items (the "waiting" counter is
+  zero), clicking the counter will now select all visible UAVs that have no
   upload status.
 
 ### Changed

--- a/src/features/upload/UploadStatusLegend.tsx
+++ b/src/features/upload/UploadStatusLegend.tsx
@@ -51,7 +51,11 @@ const UploadStatusLegend = ({
         disabled={isUploadInProgress}
         label={t('general.status.waiting')}
         status={Status.INFO}
-        tooltip={t('uploadStatusLegend.clearUploadQueue')}
+        tooltip={
+          waiting === 0
+            ? t('uploadStatusLegend.enqueueItemsWithNoUploadStatus')
+            : t('uploadStatusLegend.clearUploadQueue')
+        }
         onClick={() => {
           if (waiting === 0) {
             enqueueItemsWithNoUploadStatus();

--- a/src/features/upload/UploadStatusLegend.tsx
+++ b/src/features/upload/UploadStatusLegend.tsx
@@ -1,74 +1,108 @@
 import Box from '@mui/material/Box';
-import type { TFunction } from 'i18next';
-import type React from 'react';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import { Status } from '~/components/semantics';
+import type { RootState } from '~/store/reducers';
 
-import { restartSuccessfulUploads, retryFailedUploads } from './actions';
-import { getUploadStatusCodeCounters } from './selectors';
+import {
+  enqueueFailedUploads,
+  enqueueItemsWithNoUploadStatus,
+  enqueueSuccessfulUploads,
+} from './actions';
+import { getUploadStatusCodeCounters, isUploadInProgress } from './selectors';
 import { clearUploadQueue } from './slice';
 import UploadStatusLegendButton from './UploadStatusLegendButton';
 
-type UploadStatusLegendProps = Readonly<{
+type StateProps = {
   failed: number;
   finished: number;
   inProgress: number;
+  isUploadInProgress: boolean;
   waiting: number;
-  onClearUploadQueue: () => void;
-  onRestartSuccessfulUploads: () => void;
-  onRetryFailedUploads: () => void;
-  t: TFunction;
-}>;
+};
+
+type DispatchProps = {
+  enqueueItemsWithNoUploadStatus: () => void;
+  clearUploadQueue: () => void;
+  enqueueSuccessfulUploads: () => void;
+  enqueueFailedUploads: () => void;
+};
+
+type UploadStatusLegendProps = StateProps & DispatchProps;
 
 const UploadStatusLegend = ({
   failed,
   finished,
   inProgress,
-  onClearUploadQueue,
-  onRestartSuccessfulUploads,
-  onRetryFailedUploads,
-  t,
+  isUploadInProgress,
+  clearUploadQueue,
+  enqueueSuccessfulUploads,
+  enqueueFailedUploads,
+  enqueueItemsWithNoUploadStatus,
   waiting,
-}: UploadStatusLegendProps): React.JSX.Element => (
-  <Box sx={{ display: 'flex', justifyContent: 'space-around' }}>
-    <UploadStatusLegendButton
-      counter={waiting}
-      label={t('general.status.waiting')}
-      status={Status.INFO}
-      tooltip={t('uploadStatusLegend.clearUploadQueue')}
-      onClick={onClearUploadQueue}
-    />
-    <UploadStatusLegendButton
-      counter={inProgress}
-      label={t('general.status.inProgress')}
-      status={Status.WARNING}
-    />
-    <UploadStatusLegendButton
-      counter={finished}
-      label={t('general.status.successful')}
-      tooltip={t('uploadStatusLegend.restartSuccessfulItems')}
-      status={Status.SUCCESS}
-      onClick={onRestartSuccessfulUploads}
-    />
-    <UploadStatusLegendButton
-      counter={failed}
-      label={t('general.status.failed')}
-      status={Status.ERROR}
-      tooltip={t('uploadStatusLegend.retryFailedItems')}
-      onClick={onRetryFailedUploads}
-    />
-  </Box>
-);
+}: UploadStatusLegendProps) => {
+  const { t } = useTranslation();
 
-export default connect(
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-around' }}>
+      <UploadStatusLegendButton
+        counter={waiting}
+        disabled={isUploadInProgress}
+        label={t('general.status.waiting')}
+        status={Status.INFO}
+        tooltip={t('uploadStatusLegend.clearUploadQueue')}
+        onClick={() => {
+          if (waiting === 0) {
+            enqueueItemsWithNoUploadStatus();
+          } else {
+            clearUploadQueue();
+          }
+        }}
+      />
+      <UploadStatusLegendButton
+        disabled
+        counter={inProgress}
+        label={t('general.status.inProgress')}
+        status={Status.WARNING}
+      />
+      <UploadStatusLegendButton
+        counter={finished}
+        disabled={finished === 0}
+        label={t('general.status.successful')}
+        tooltip={t('uploadStatusLegend.restartSuccessfulItems')}
+        status={Status.SUCCESS}
+        onClick={() => {
+          enqueueSuccessfulUploads();
+        }}
+      />
+      <UploadStatusLegendButton
+        counter={failed}
+        disabled={failed === 0}
+        label={t('general.status.failed')}
+        status={Status.ERROR}
+        tooltip={t('uploadStatusLegend.retryFailedItems')}
+        onClick={() => {
+          enqueueFailedUploads();
+        }}
+      />
+    </Box>
+  );
+};
+
+const ConnectedUploadStatusLegend = connect(
   // mapStateToProps
-  getUploadStatusCodeCounters,
+  (state: RootState) => ({
+    ...getUploadStatusCodeCounters(state),
+    isUploadInProgress: isUploadInProgress(state),
+  }),
   // mapDispatchToProps
   {
-    onClearUploadQueue: clearUploadQueue,
-    onRestartSuccessfulUploads: restartSuccessfulUploads,
-    onRetryFailedUploads: retryFailedUploads,
+    clearUploadQueue,
+    enqueueFailedUploads,
+    enqueueItemsWithNoUploadStatus,
+    enqueueSuccessfulUploads,
   }
-)(withTranslation()(UploadStatusLegend));
+)(UploadStatusLegend);
+
+export default ConnectedUploadStatusLegend;

--- a/src/features/upload/UploadStatusLegendButton.tsx
+++ b/src/features/upload/UploadStatusLegendButton.tsx
@@ -41,10 +41,11 @@ type UploadStatusLegendButtonProps = Readonly<{
   tooltip?: Nullable<string>;
   onClick?: () => void;
 }> &
-  ButtonBaseProps;
+  Omit<ButtonBaseProps, 'className' | 'onClick'>;
 
 const UploadStatusLegendButton = ({
   counter,
+  disabled,
   label,
   onClick,
   status,
@@ -52,11 +53,10 @@ const UploadStatusLegendButton = ({
   ...rest
 }: UploadStatusLegendButtonProps): React.JSX.Element => {
   const classes = useStyles();
-  const enabled = onClick && counter > 0;
   const button = (
     <ButtonBase
-      className={clsx(classes.root, enabled && classes.selectable)}
-      disabled={!enabled}
+      className={clsx(classes.root, !disabled && classes.selectable)}
+      disabled={disabled}
       onClick={onClick}
       {...rest}
     >

--- a/src/features/upload/actions.ts
+++ b/src/features/upload/actions.ts
@@ -9,6 +9,7 @@ import {
   getSelectedJobInUploadDialog,
   getSuccessfulUploadItemsToEnqueue,
   getUploadDialogState,
+  getUploadItemsWithNoUploadStatus,
   getUploadTargets,
   isItemInUploadBacklog,
 } from './selectors';
@@ -72,10 +73,9 @@ export function recalculateEstimatedCompletionTime(): AppThunk<void> {
 }
 
 /**
- * Thunk that restarts the upload process on all UAVs that are currently
- * marked as successful.
+ * Thunk that enqueues all upload items whose latest status is success.
  */
-export function restartSuccessfulUploads(): AppThunk<void> {
+export function enqueueSuccessfulUploads(): AppThunk<void> {
   return (dispatch, getState) => {
     const successfulItems = getSuccessfulUploadItemsToEnqueue(getState());
     dispatch(_enqueueSuccessfulUploads(successfulItems));
@@ -83,13 +83,25 @@ export function restartSuccessfulUploads(): AppThunk<void> {
 }
 
 /**
- * Thunk that retrieves all failed upload items from the state, places all of
- * them in the upload queue and then restarts the upload process if needed.
+ * Thunk that enqueues all upload items whose latest status is failure.
  */
-export function retryFailedUploads(): AppThunk<void> {
+export function enqueueFailedUploads(): AppThunk<void> {
   return (dispatch, getState) => {
     const failedItems = getFailedUploadItemsToEnqueue(getState());
     dispatch(_enqueueFailedUploads(failedItems));
+  };
+}
+
+/**
+ * Thunk that enqueues all upload items with no upload status.
+ */
+export function enqueueItemsWithNoUploadStatus(): AppThunk<void> {
+  return (dispatch, getState) => {
+    const itemsWithNoUploadStatus =
+      getUploadItemsWithNoUploadStatus(getState());
+    if (itemsWithNoUploadStatus.length > 0) {
+      dispatch(putUavsInWaitingQueue(itemsWithNoUploadStatus));
+    }
   };
 }
 

--- a/src/features/upload/selectors.ts
+++ b/src/features/upload/selectors.ts
@@ -14,7 +14,6 @@ import {
 } from '~/features/uavs/selectors';
 import { uavIdToGlobalId } from '~/model/identifiers';
 import type { RootState } from '~/store/reducers';
-import { rejectNullish } from '~/utils/arrays';
 import type { Identifier } from '~/utils/collections';
 import { formatMissionId } from '~/utils/formatting';
 import { EMPTY_ARRAY } from '~/utils/redux';
@@ -367,22 +366,6 @@ export const getMissionIdFormatter = createSelector(
   }
 );
 
-export const getMissionMapping = createSelector(
-  _getFullMissionMapping,
-  getSelection,
-  shouldRestrictToGlobalSelection,
-  (missionMapping, selection, restrictToGlobalSelection) => {
-    if (!restrictToGlobalSelection) {
-      return missionMapping;
-    }
-
-    const allowedIds = new Set(selection);
-    return missionMapping.filter(
-      (id) => id !== null && allowedIds.has(uavIdToGlobalId(id))
-    );
-  }
-);
-
 /**
  * Factory that creates a selector that returns the upload status for
  * the given job type, taking all UAVs in the mission into account.
@@ -582,7 +565,7 @@ export const getUploadProgress = createSelector(
   }
 );
 
-export const getUAVIdList = createSelector(
+const getUAVIdList = createSelector(
   _getAllKnownUAVIds,
   getSelection,
   shouldRestrictToGlobalSelection,
@@ -610,8 +593,20 @@ export const getUAVIdList = createSelector(
  * by the server but are nevertheless in the mapping.
  */
 const getMissionUAVIdsForUploadJob = createSelector(
-  getMissionMapping,
-  (mapping) => rejectNullish(mapping)
+  _getFullMissionMapping,
+  getSelection,
+  shouldRestrictToGlobalSelection,
+  (missionMapping, selection, restrictToGlobalSelection): Identifier[] => {
+    if (!restrictToGlobalSelection) {
+      return missionMapping.filter((id): id is Identifier => id !== null);
+    }
+
+    const allowedIds = new Set(selection);
+    return missionMapping.filter(
+      (id): id is Identifier =>
+        id !== null && allowedIds.has(uavIdToGlobalId(id))
+    );
+  }
 );
 
 /**
@@ -649,6 +644,15 @@ export const getUploadDialogIdList = createSelector(
 
     return result;
   }
+);
+
+/**
+ * Returns all potential upload items that have no upload status.
+ */
+export const getUploadItemsWithNoUploadStatus = createSelector(
+  getUploadDialogIdList,
+  getUploadStatusCodeMappingForSelectedJobType,
+  (dialogIds, statuses) => dialogIds.filter((id) => statuses[id] === undefined)
 );
 
 /**

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1044,7 +1044,7 @@
   },
   "uploadStatusLegend": {
     "clearUploadQueue": "Clear upload queue",
-    "enqueueItemsWithNoUploadStatus": "Enqueue items with no upload status",
+    "enqueueItemsWithNoUploadStatus": "Enqueue unprocessed items",
     "restartSuccessfulItems": "Enqueue successful items",
     "retryFailedItems": "Enqueue failed items"
   },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1044,6 +1044,7 @@
   },
   "uploadStatusLegend": {
     "clearUploadQueue": "Clear upload queue",
+    "enqueueItemsWithNoUploadStatus": "Enqueue items with no upload status",
     "restartSuccessfulItems": "Enqueue successful items",
     "retryFailedItems": "Enqueue failed items"
   },


### PR DESCRIPTION
... if the waiting queue is empty. If the waiting queue has items, clicking the button clears it (just like before).

Note: "all" means all UAVs that are visible in the dialog (meaning the "show global selection only" option is respected).

There is also a bit of related cleanup.