### PR TITLE
feat: add RTH method to show adapt params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added RTH method parameter to the show adaptation dialog box.
+
 ## [2.13.2] - 2026-04-16
 
 ### Fixed

--- a/src/features/show-configurator/AdaptParametersForm.tsx
+++ b/src/features/show-configurator/AdaptParametersForm.tsx
@@ -7,7 +7,7 @@ import FormControl from '@mui/material/FormControl';
 import FormGroup from '@mui/material/FormGroup';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
-import Select, { SelectChangeEvent } from '@mui/material/Select';
+import Select, { type SelectChangeEvent } from '@mui/material/Select';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/show-configurator/AdaptParametersForm.tsx
+++ b/src/features/show-configurator/AdaptParametersForm.tsx
@@ -20,8 +20,10 @@ import {
 } from '~/components/forms/fields';
 
 import {
+  RETURN_TO_HOME_METHODS,
   TAKEOFF_METHODS,
   type OptionalShowAdaptParameters,
+  type ReturnToHomeMethodType,
   type ShowAdaptParameters,
   type TakeoffMethodType,
 } from './actions';
@@ -37,6 +39,7 @@ const defaultAdaptParameters: ShowAdaptParameters = {
   verticalVelocity: 1.5,
   takeoffDuration: 0,
   takeoffMethod: 'layered',
+  returnToHomeMethod: 'smart',
 };
 
 const useStyles = makeStyles((theme) => ({
@@ -110,6 +113,9 @@ export function useAdaptParametersFormState(
       defaultAdaptParameters.takeoffDuration,
     takeoffMethod:
       defaultParameters?.takeoffMethod ?? defaultAdaptParameters.takeoffMethod,
+    returnToHomeMethod:
+      defaultParameters?.returnToHomeMethod ??
+      defaultAdaptParameters.returnToHomeMethod,
   });
   const [isValid, setIsValid] = useState(adaptParametersValid(parameters));
 
@@ -212,6 +218,27 @@ export function useAdaptParametersFormState(
     },
     [onChange, parameters]
   );
+  const onReturnToHomeMethodChanged = useCallback(
+    (
+      event:
+        | React.ChangeEvent<{ value: string }>
+        | { target: { value: string } }
+    ) => {
+      const value: ReturnToHomeMethodType = RETURN_TO_HOME_METHODS.includes(
+        event.target.value as ReturnToHomeMethodType
+      )
+        ? (event.target.value as ReturnToHomeMethodType)
+        : 'smart';
+      const newParameters: ShowAdaptParameters = {
+        ...parameters,
+        returnToHomeMethod: value,
+      };
+      setParameters(newParameters);
+      setIsValid(adaptParametersValid(newParameters));
+      onChange?.();
+    },
+    [onChange, parameters]
+  );
 
   return {
     parameters,
@@ -223,6 +250,7 @@ export function useAdaptParametersFormState(
     onVerticalVelocityChanged,
     onTakeoffDurationChanged,
     onTakeoffMethodChanged,
+    onReturnToHomeMethodChanged,
   };
 }
 
@@ -244,6 +272,7 @@ const AdaptParametersForm = (props: Props): React.JSX.Element => {
     onVerticalVelocityChanged,
     onTakeoffDurationChanged,
     onTakeoffMethodChanged,
+    onReturnToHomeMethodChanged,
   } = props;
   const { t } = useTranslation(undefined, {
     keyPrefix: 'showConfiguratorDialog.adaptParameters',
@@ -348,6 +377,23 @@ const AdaptParametersForm = (props: Props): React.JSX.Element => {
                 {TAKEOFF_METHODS.map((value) => (
                   <MenuItem key={value} value={value}>
                     {t(`form.takeoffMethod.type.${value}`)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl fullWidth variant='filled'>
+              <InputLabel id='rth-method-label'>
+                {t('form.returnToHomeMethod.label')}
+              </InputLabel>
+              <Select
+                disabled={disabled}
+                labelId='rth-method-label'
+                value={parameters.returnToHomeMethod}
+                onChange={onReturnToHomeMethodChanged}
+              >
+                {RETURN_TO_HOME_METHODS.map((value) => (
+                  <MenuItem key={value} value={value}>
+                    {t(`form.returnToHomeMethod.type.${value}`)}
                   </MenuItem>
                 ))}
               </Select>

--- a/src/features/show-configurator/AdaptParametersForm.tsx
+++ b/src/features/show-configurator/AdaptParametersForm.tsx
@@ -7,7 +7,7 @@ import FormControl from '@mui/material/FormControl';
 import FormGroup from '@mui/material/FormGroup';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
-import Select from '@mui/material/Select';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -198,11 +198,7 @@ export function useAdaptParametersFormState(
     [onChange, parameters]
   );
   const onTakeoffMethodChanged = useCallback(
-    (
-      event:
-        | React.ChangeEvent<{ value: string }>
-        | { target: { value: string } }
-    ) => {
+    (event: SelectChangeEvent) => {
       const value: TakeoffMethodType = TAKEOFF_METHODS.includes(
         event.target.value as TakeoffMethodType
       )

--- a/src/features/show-configurator/actions.ts
+++ b/src/features/show-configurator/actions.ts
@@ -297,8 +297,13 @@ type Meters = number;
 type MetersPerSecond = number;
 type Seconds = number;
 export type TakeoffMethodType = 'layered' | 'organic';
+export type ReturnToHomeMethodType = 'plain' | 'smart';
 
 export const TAKEOFF_METHODS: TakeoffMethodType[] = ['layered', 'organic'];
+export const RETURN_TO_HOME_METHODS: ReturnToHomeMethodType[] = [
+  'plain',
+  'smart',
+];
 
 export type OptionalShowAdaptParameters = {
   altitude?: Meters;
@@ -308,6 +313,7 @@ export type OptionalShowAdaptParameters = {
   verticalVelocity?: MetersPerSecond;
   takeoffDuration?: Seconds;
   takeoffMethod?: TakeoffMethodType;
+  returnToHomeMethod?: ReturnToHomeMethodType;
 };
 
 export type ShowAdaptParameters = Required<OptionalShowAdaptParameters>;
@@ -427,6 +433,7 @@ export const adaptShow =
       {
         type: 'rth',
         parameters: {
+          method: params.returnToHomeMethod,
           lights,
           ...common,
         },

--- a/src/i18n/dynamic-keys.ts
+++ b/src/i18n/dynamic-keys.ts
@@ -85,6 +85,10 @@
  * t("preflightCheckResult.overall.error")
  * t("preflightCheckResult.overall.unknown")
  *
+ * Return to home methods
+ * t("form.returnToHomeMethod.type.plain")
+ * t("form.returnToHomeMethod.type.smart")
+ *
  * RTK correction status (long)
  * t("rtkCorrectionStatus.long.connectedRecently")
  * t("rtkCorrectionStatus.long.error")

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1111,6 +1111,13 @@
           "help": "between drones during takeoff & RTH",
           "label": "Minimum distance"
         },
+        "returnToHomeMethod": {
+          "label": "RTH method",
+          "type": {
+            "plain": "Plain",
+            "smart": "Smart"
+          }
+        },
         "takeoffDuration": {
           "help": "ensuring exact start of show phase (if nonzero)",
           "label": "Takeoff duration"


### PR DESCRIPTION
This PR adds RTH method to the show adapt trajectory params, similarly to already existing takeoff method. Functionality is already supported in the official latest version of the pro server, tested also, no need to update the server to support this new param.

One issue with the "organic takeoff + plain rth" combination: the plain RTH first brings drones to the end of their takeoff trajectories, but if organic takeoff is selected, this will be at the same altitude for all drones (as in organic takeoff they takeoff to the same height but in different times), possibly resulting in a min distance deviation if the single-layer takeoff is too dense. We might notify the user about this...