### PR TITLE
Feat/display num drones selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added RTH method parameter to the show adaptation dialog box.
+- Added selected item count to the Selection groups header widget, matching the
+  typography of the neighboring UAV status widget.
 
 ## [2.13.2] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added RTH method parameter to the show adaptation dialog box.
-- Added selected item count to the Selection groups header widget, matching the
-  typography of the neighboring UAV status widget.
+- Added selected item count to the Selection groups header widget.
 
 ## [2.13.2] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added RTH method parameter to the show adaptation dialog box.
+
 - Added selected item count to the Selection groups header widget.
 
 ## [2.13.2] - 2026-04-16

--- a/src/components/uavs/UAVStatusSummary.tsx
+++ b/src/components/uavs/UAVStatusSummary.tsx
@@ -95,7 +95,6 @@ const getStatusSummary = createShallowSelector(
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    fontSize: '1rem',
     cursor: 'pointer',
   },
 
@@ -127,7 +126,6 @@ const useStyles = makeStyles((theme) => ({
     color: 'white',
     display: 'flex',
     flexDirection: 'row',
-    fontSize: '1rem',
     fontWeight: 'normal',
     paddingLeft: 0,
     paddingRight: 0,

--- a/src/features/selection/SelectionGroupMiniList.tsx
+++ b/src/features/selection/SelectionGroupMiniList.tsx
@@ -2,6 +2,7 @@ import {
   MiniList,
   MiniListDivider,
   MiniListItemButton,
+  MiniListItem,
 } from '@skybrush/mui-components';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
@@ -10,7 +11,11 @@ import { useAppDispatch } from '~/store/hooks';
 
 import { saveCurrentSelectionAsGroupIfNotEmpty } from './actions';
 import SelectionGroupMiniListItem from './SelectionGroupMiniListItem';
-import { getOrderedSelectionGroups, hasSelection } from './selectors';
+import {
+  getNumberOfSelectedItems,
+  getOrderedSelectionGroups,
+  hasSelection,
+} from './selectors';
 
 const listStyle = {
   minWidth: 200,
@@ -18,6 +23,7 @@ const listStyle = {
 
 const SelectionGroupMiniList = () => {
   const isSelectionNotEmpty = useSelector(hasSelection);
+  const numberOfSelectedItems = useSelector(getNumberOfSelectedItems);
   const selectionGroups = useSelector(getOrderedSelectionGroups);
   const dispatch = useAppDispatch();
   const { t } = useTranslation(undefined, {
@@ -26,6 +32,11 @@ const SelectionGroupMiniList = () => {
 
   return (
     <MiniList style={listStyle}>
+      <MiniListItem
+        primaryText={t('selectedObjects')}
+        secondaryText={String(numberOfSelectedItems)}
+      />
+      <MiniListDivider />
       {selectionGroups.map((group) => (
         <SelectionGroupMiniListItem key={group.id} group={group} />
       ))}

--- a/src/features/selection/SelectionGroupsHeaderButton.tsx
+++ b/src/features/selection/SelectionGroupsHeaderButton.tsx
@@ -13,11 +13,6 @@ const SelectionGroupMenuButton = () => {
     <LazyTooltip interactive content={<SelectionGroupMiniList />}>
       <GenericHeaderButton
         label={numberOfSelectedItems > 0 ? String(numberOfSelectedItems) : '—'}
-        style={{
-          fontSize: '1rem',
-          fontWeight: 'normal',
-          fontFamily: 'inherit',
-        }}
       >
         <Workspaces />
       </GenericHeaderButton>

--- a/src/features/selection/SelectionGroupsHeaderButton.tsx
+++ b/src/features/selection/SelectionGroupsHeaderButton.tsx
@@ -1,13 +1,19 @@
 import Workspaces from '@mui/icons-material/Workspaces';
+import { useSelector } from 'react-redux';
 
 import { GenericHeaderButton, LazyTooltip } from '@skybrush/mui-components';
 
 import SelectionGroupMiniList from './SelectionGroupMiniList';
+import { getNumberOfSelectedItems } from './selectors';
 
 const SelectionGroupMenuButton = () => {
+  const numberOfSelectedItems = useSelector(getNumberOfSelectedItems);
+
   return (
     <LazyTooltip interactive content={<SelectionGroupMiniList />}>
-      <GenericHeaderButton>
+      <GenericHeaderButton
+        label={numberOfSelectedItems > 0 ? String(numberOfSelectedItems) : '—'}
+      >
         <Workspaces />
       </GenericHeaderButton>
     </LazyTooltip>

--- a/src/features/selection/SelectionGroupsHeaderButton.tsx
+++ b/src/features/selection/SelectionGroupsHeaderButton.tsx
@@ -13,7 +13,7 @@ const SelectionGroupMenuButton = () => {
     <LazyTooltip interactive content={<SelectionGroupMiniList />}>
       <GenericHeaderButton
         label={numberOfSelectedItems > 0 ? String(numberOfSelectedItems) : '—'}
-        style={{ fontSize: '1rem' }}
+        style={{ fontSize: '1rem', fontWeight: 'normal', fontFamily: 'inherit' }}
       >
         <Workspaces />
       </GenericHeaderButton>

--- a/src/features/selection/SelectionGroupsHeaderButton.tsx
+++ b/src/features/selection/SelectionGroupsHeaderButton.tsx
@@ -13,7 +13,11 @@ const SelectionGroupMenuButton = () => {
     <LazyTooltip interactive content={<SelectionGroupMiniList />}>
       <GenericHeaderButton
         label={numberOfSelectedItems > 0 ? String(numberOfSelectedItems) : '—'}
-        style={{ fontSize: '1rem', fontWeight: 'normal', fontFamily: 'inherit' }}
+        style={{
+          fontSize: '1rem',
+          fontWeight: 'normal',
+          fontFamily: 'inherit',
+        }}
       >
         <Workspaces />
       </GenericHeaderButton>

--- a/src/features/selection/SelectionGroupsHeaderButton.tsx
+++ b/src/features/selection/SelectionGroupsHeaderButton.tsx
@@ -13,6 +13,7 @@ const SelectionGroupMenuButton = () => {
     <LazyTooltip interactive content={<SelectionGroupMiniList />}>
       <GenericHeaderButton
         label={numberOfSelectedItems > 0 ? String(numberOfSelectedItems) : '—'}
+        style={{ fontSize: '1rem' }}
       >
         <Workspaces />
       </GenericHeaderButton>

--- a/src/features/selection/selectors.ts
+++ b/src/features/selection/selectors.ts
@@ -64,6 +64,14 @@ export const hasSelection: AppSelector<boolean> = (state) =>
   state.selection.ids.length > 0;
 
 /**
+ * Returns the number of currently selected items.
+ */
+export const getNumberOfSelectedItems: AppSelector<number> = createSelector(
+  getSelection,
+  (selection) => selection.length
+);
+
+/**
  * Selector factory that creates a selector that returns true if and only if a
  * feature with the given ID is selected.
  */

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -874,6 +874,7 @@
       "name": "Group name"
     },
     "newGroupNameTemplate": "Group {{id}}",
+    "selectedObjects": "Selected objects",
     "updated": "Updated"
   },
   "serverConnectionStatus": {

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -679,6 +679,7 @@
     },
     "label": "Csoportok",
     "newGroupNameTemplate": "{{id}}. csoport",
+    "selectedObjects": "Kijelölt objektumok",
     "updated": "Frissítve"
   },
   "serverConnectionStatus": {


### PR DESCRIPTION
This branch adds a selected-items counter to the selection groups header button by introducing a new Redux selector (`getNumberOfSelectedItems`) and wiring it into `SelectionGroupsHeaderButton`, so the button now shows the current selected count (or `—` when none are selected).

Fixes #183.