### PR TITLE
Convert Message.id to string, convert message selectors to ts

### DIFF
--- a/src/features/messages/selectors.ts
+++ b/src/features/messages/selectors.ts
@@ -1,12 +1,14 @@
 import { createSelector } from '@reduxjs/toolkit';
 
-import { reorder, selectOrdered } from '~/utils/collections';
+import { reorder, selectOrdered, type Identifier } from '~/utils/collections';
 import { EMPTY_ARRAY } from '~/utils/redux';
+
+import type { AppSelector, RootState } from '~/store/reducers';
 
 export function createMessageListSelector() {
   return createSelector(
-    (state) => state.messages,
-    (state, uavId) =>
+    (state: RootState) => state.messages,
+    (state: RootState, uavId: Identifier) =>
       state.messages.uavIdsToMessageIds
         ? state.messages.uavIdsToMessageIds[uavId]
         : undefined,
@@ -17,4 +19,5 @@ export function createMessageListSelector() {
   );
 }
 
-export const getCommandHistory = (state) => state.messages.commandHistory;
+export const getCommandHistory: AppSelector<string[]> = (state) =>
+  state.messages.commandHistory;

--- a/src/features/messages/slice.ts
+++ b/src/features/messages/slice.ts
@@ -45,7 +45,11 @@ const { actions, reducer } = createSlice({
   reducers: {
     addErrorMessage(
       state,
-      action: PayloadAction<{ message: string; refs?: Message['id']; uavId: string }>
+      action: PayloadAction<{
+        message: string;
+        refs?: Message['id'];
+        uavId: string;
+      }>
     ) {
       const { message, refs, uavId } = action.payload;
 

--- a/src/features/messages/slice.ts
+++ b/src/features/messages/slice.ts
@@ -45,7 +45,7 @@ const { actions, reducer } = createSlice({
   reducers: {
     addErrorMessage(
       state,
-      action: PayloadAction<{ message: string; refs?: number; uavId: string }>
+      action: PayloadAction<{ message: string; refs?: Message['id']; uavId: string }>
     ) {
       const { message, refs, uavId } = action.payload;
 
@@ -67,7 +67,7 @@ const { actions, reducer } = createSlice({
       state,
       action: PayloadAction<{
         message: string;
-        refs?: number;
+        refs?: Message['id'];
         severity?: Severity;
         uavId: string;
       }>
@@ -97,7 +97,7 @@ const { actions, reducer } = createSlice({
       action: PayloadAction<
         Array<{
           message: string;
-          refs?: number;
+          refs?: Message['id'];
           severity?: Severity;
           uavId: string;
         }>

--- a/src/features/messages/types.ts
+++ b/src/features/messages/types.ts
@@ -1,10 +1,11 @@
-import { type MessageType, type Severity } from '~/model/enums';
+import type { MessageType, Severity } from '~/model/enums';
+import type { Identifier } from '~/utils/collections';
 
 export type Message = {
   author?: string;
   body: string;
   date: number;
-  id: number;
+  id: Identifier;
   message?: string;
   percentage?: number;
   raw?: boolean;

--- a/src/features/messages/utils.ts
+++ b/src/features/messages/utils.ts
@@ -7,9 +7,12 @@ export function addMessage(
   state: Draft<MessagesSliceState>,
   messageStub: Omit<Message, 'id'>,
   peer: string,
-  refs?: number
+  refs?: Message['id']
 ): Message['id'] {
-  const message: Message = { id: state.nextMessageId++, ...messageStub };
+  const message: Message = {
+    id: (state.nextMessageId++).toFixed(),
+    ...messageStub,
+  };
 
   if (refs !== undefined) {
     const originalMessage = state.byId[refs];

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -495,7 +495,7 @@ export const selectOrdered = <T extends ItemLike>({
  * @returns The reordered collection
  */
 export const reorder = <T extends ItemLike>(
-  collection: Collection<T>,
+  collection: Omit<Collection<T>, 'order'>,
   newOrder: Identifier[]
 ): Collection<T> => ({
   ...collection,


### PR DESCRIPTION
The PR converts `messages/selectors` to TS. To do this, I had to change `Message.id` from `number` to `string` and loosen the typing of `reorder()` in `collections` (the input doesn't need to have an `order` property).