### PR TITLE
fix: convert clock epoch to Number before isNaN check to fix error wh…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@rjsf/utils": "^6.1.2",
         "@rjsf/validator-ajv8": "^6.1.2",
         "@skybrush/aframe-components": "^2.0.0",
-        "@skybrush/app-theme-mui": "^4.0.1",
+        "@skybrush/app-theme-mui": "^5.0.2",
         "@skybrush/electron-app-framework": "^5.1.0",
         "@skybrush/flockwave-spec": "^2.8.0",
         "@skybrush/mui-components": "^6.4.1",
@@ -4337,9 +4337,9 @@
       }
     },
     "node_modules/@skybrush/app-theme-mui": {
-      "version": "4.0.4",
-      "resolved": "https://npm.collmot.com/@skybrush%2fapp-theme-mui/-/app-theme-mui-4.0.4.tgz",
-      "integrity": "sha512-B6DaLHuBQ6otcV6xpwFmLheqYzaVJ87kWs0DuTEOGiRBMIk/TV6oumyl8LBdEcS0Z+qd6hwg74HaKnBHmnECtg==",
+      "version": "5.0.2",
+      "resolved": "https://npm.collmot.com/@skybrush%2fapp-theme-mui/-/app-theme-mui-5.0.2.tgz",
+      "integrity": "sha512-rq4kyz8y5/XQ7Zs5hxDpGkzHVWIQbH9ZR3p14EQeSQbVSV6+/PSqZhH3fs9g+AQ9RMbs8vu+kn78tUWB/23kRg==",
       "license": "MIT",
       "dependencies": {
         "@emotion/css": "^11.13.5",
@@ -4411,22 +4411,6 @@
         "@mui/icons-material": "^7",
         "@mui/material": "^7",
         "@mui/styled-engine": "^7",
-        "react": "^18",
-        "react-dom": "^18"
-      }
-    },
-    "node_modules/@skybrush/mui-components/node_modules/@skybrush/app-theme-mui": {
-      "version": "5.0.2",
-      "resolved": "https://npm.collmot.com/@skybrush%2fapp-theme-mui/-/app-theme-mui-5.0.2.tgz",
-      "integrity": "sha512-rq4kyz8y5/XQ7Zs5hxDpGkzHVWIQbH9ZR3p14EQeSQbVSV6+/PSqZhH3fs9g+AQ9RMbs8vu+kn78tUWB/23kRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/css": "^11.13.5",
-        "color": "^5.0.3",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "@mui/material": "^7",
         "react": "^18",
         "react-dom": "^18"
       }

--- a/src/features/clocks/utils.ts
+++ b/src/features/clocks/utils.ts
@@ -99,7 +99,12 @@ export function formatTicksOnClock(
   const { format = clock.format } = options;
   let seconds = ticks / ticksPerSecond;
 
-  if (Number.isNaN(epoch)) {
+  // TODO: remove the `Number(epoch)` conversion when everything is converted
+  // to TypeScript.
+  // Convert to number, apparently it may happen that clock.epoch is null
+  // and we would then get an exception. This happens for example when Live
+  // connects to the server.
+  if (Number.isNaN(Number(epoch))) {
     if (clock.id === String(CommonClockId.MTC)) {
       // No epoch, so we just simply show a HH:MM:SS:FF SMPTE-style
       // timestamp. We (ab)use the millisecond part of the timestamp


### PR DESCRIPTION
Gábor's fix.

Issue: Live throws an error when connecting to a server, because `epoch` is not a `Number`.