### PR TITLE
Convert more UAVDetailsDialog dependencies to TS

### DIFF
--- a/src/features/snackbar/types.ts
+++ b/src/features/snackbar/types.ts
@@ -14,7 +14,7 @@ export enum MessageSemantics {
 
 type ToastButton = {
   label: string;
-  action: Action;
+  action: Action | (() => void);
 };
 
 /**

--- a/src/features/uavs/UAVLogsPanel.tsx
+++ b/src/features/uavs/UAVLogsPanel.tsx
@@ -9,13 +9,12 @@ import ListItemText from '@mui/material/ListItemText';
 import Typography from '@mui/material/Typography';
 import isNil from 'lodash-es/isNil';
 import prettyBytes from 'pretty-bytes';
-import PropTypes from 'prop-types';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { useAsyncRetry } from 'react-use';
 
-import { makeStyles } from '@skybrush/app-theme-mui';
+import { makeStyles, Status } from '@skybrush/app-theme-mui';
 import {
   BackgroundHint,
   LargeProgressIndicator,
@@ -34,9 +33,15 @@ import {
   setLogDownloadProgress,
   storeDownloadedLog,
 } from '~/features/uavs/log-download';
+import type { ProgressStatus } from '~/flockwave/messages';
 import useMessageHub from '~/hooks/useMessageHub';
 import { describeFlightLogKind } from '~/model/enums';
-import { convertFlightLogToBlob } from '~/model/flight-logs';
+import {
+  convertFlightLogToBlob,
+  type FlightLog,
+  type FlightLogMetadata,
+} from '~/model/flight-logs';
+import { useAppDispatch } from '~/store/hooks';
 import { writeBlobToFile } from '~/utils/filesystem';
 import { formatUnixTimestamp } from '~/utils/formatting';
 
@@ -52,15 +57,25 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const saveLogToFile = (log) => {
+const saveLogToFile = (log: FlightLog) => {
   const { filename, blob } = convertFlightLogToBlob(log);
-  writeBlobToFile(blob, filename);
+  void writeBlobToFile(blob, filename);
 };
 
-const UAVLogListItem = ({ id, kind, size, timestamp, uavId }) => {
+type UAVLogListItemProps = FlightLogMetadata & {
+  uavId: string;
+};
+
+const UAVLogListItem = ({
+  id,
+  kind,
+  size,
+  timestamp,
+  uavId,
+}: UAVLogListItemProps) => {
   /* Hooks */
 
-  const dispatch = useDispatch();
+  const dispatch = useAppDispatch();
   const messageHub = useMessageHub();
   const { t } = useTranslation();
   const classes = useStyles();
@@ -72,12 +87,12 @@ const UAVLogListItem = ({ id, kind, size, timestamp, uavId }) => {
     dispatch(initiateLogDownload(uavId, id));
     messageHub.query
       .getFlightLog(uavId, id, {
-        onProgress({ progress }) {
+        onProgress({ progress }: ProgressStatus) {
           dispatch(setLogDownloadProgress(uavId, id, progress));
         },
       })
       .then((log) => {
-        dispatch(storeDownloadedLog(uavId, id, log));
+        void dispatch(storeDownloadedLog(uavId, id, log));
         showNotification({
           message: `Log ${id} of UAV ${uavId} downloaded successfully.`,
           semantics: MessageSemantics.SUCCESS,
@@ -85,7 +100,7 @@ const UAVLogListItem = ({ id, kind, size, timestamp, uavId }) => {
           timeout: 20000,
         });
       })
-      .catch(({ message }) => {
+      .catch(({ message }: { message: string }) => {
         showNotification({
           message: `Couldn't download log ${id} of UAV ${uavId}: ${message}`,
           semantics: MessageSemantics.ERROR,
@@ -97,13 +112,15 @@ const UAVLogListItem = ({ id, kind, size, timestamp, uavId }) => {
   }, [dispatch, id, messageHub, uavId]);
 
   const save = useCallback(() => {
-    saveLogToFile(log);
+    if (log) {
+      saveLogToFile(log);
+    }
   }, [log]);
 
   /* Display */
 
-  const primaryParts = [];
-  const secondaryParts = [];
+  const primaryParts: string[] = [];
+  const secondaryParts: string[] = [];
 
   if (!isNil(id)) {
     primaryParts.push(id);
@@ -151,11 +168,13 @@ const UAVLogListItem = ({ id, kind, size, timestamp, uavId }) => {
       <ListItemButton onClick={onClick}>
         <StatusLight
           status={
-            {
-              [LogDownloadStatus.LOADING]: 'next',
-              [LogDownloadStatus.ERROR]: 'error',
-              [LogDownloadStatus.SUCCESS]: 'success',
-            }[downloadState?.status] ?? 'off'
+            downloadState?.status
+              ? {
+                  [LogDownloadStatus.LOADING]: Status.NEXT,
+                  [LogDownloadStatus.ERROR]: Status.ERROR,
+                  [LogDownloadStatus.SUCCESS]: Status.SUCCESS,
+                }[downloadState.status]
+              : Status.OFF
           }
         />
         <ListItemText
@@ -172,16 +191,14 @@ const UAVLogListItem = ({ id, kind, size, timestamp, uavId }) => {
   );
 };
 
-UAVLogListItem.propTypes = {
-  id: PropTypes.string,
-  kind: PropTypes.string,
-  size: PropTypes.number,
-  timestamp: PropTypes.number,
-  uavId: PropTypes.string,
+type UAVLogListProps = {
+  uavId: string;
+  items: FlightLogMetadata[];
+  dense?: boolean;
 };
 
 const UAVLogList = listOf(
-  (item, props) => (
+  (item: FlightLogMetadata, props: UAVLogListProps) => (
     <UAVLogListItem key={item.id} uavId={props.uavId} {...item} />
   ),
   {
@@ -190,10 +207,15 @@ const UAVLogList = listOf(
   }
 );
 
-const UAVLogsPanel = memo(({ uavId }) => {
+type UAVLogsPanelProps = {
+  uavId?: string;
+};
+
+const UAVLogsPanel = memo(({ uavId }: UAVLogsPanelProps) => {
   const messageHub = useMessageHub();
   const state = useAsyncRetry(
-    () => (uavId ? messageHub.query.getFlightLogList(uavId) : {}),
+    () =>
+      uavId ? messageHub.query.getFlightLogList(uavId) : Promise.resolve({}),
     [messageHub, uavId]
   );
 
@@ -220,11 +242,7 @@ const UAVLogsPanel = memo(({ uavId }) => {
     );
   }
 
-  return <UAVLogList dense uavId={uavId} items={state.value} />;
+  return <UAVLogList dense uavId={uavId!} items={state.value} />;
 });
-
-UAVLogsPanel.propTypes = {
-  uavId: PropTypes.string,
-};
 
 export default UAVLogsPanel;

--- a/src/features/uavs/UAVLogsPanel.tsx
+++ b/src/features/uavs/UAVLogsPanel.tsx
@@ -245,4 +245,6 @@ const UAVLogsPanel = memo(({ uavId }: UAVLogsPanelProps) => {
   return <UAVLogList dense uavId={uavId!} items={state.value} />;
 });
 
+UAVLogsPanel.displayName = 'UAVLogsPanel';
+
 export default UAVLogsPanel;

--- a/src/features/uavs/log-download.ts
+++ b/src/features/uavs/log-download.ts
@@ -9,6 +9,7 @@ import {
 } from '@reduxjs/toolkit';
 
 import type { ProgressInfo } from '~/flockwave/messages';
+import type { FlightLog } from '~/model/flight-logs';
 import type { Identifier } from '~/utils/collections';
 import { type AppDispatch, type AppSelector } from '~/store/reducers';
 
@@ -17,13 +18,14 @@ import { type AppDispatch, type AppSelector } from '~/store/reducers';
 //       it. If we need a reusable version it should be cleaned up and moved to
 //       `~/utils`. (Or, rather, a proper CAS package should be included.)
 const logContents = new (class {
-  #data: Record<string, string> = {};
+  #data: Record<string, FlightLog> = {};
   #encoder = new TextEncoder();
-  write = async (item: string) => {
+  write = async (item: FlightLog) => {
+    const payload = JSON.stringify(item);
     // prettier-ignore
     const hash = (
       Array.from(new Uint8Array(
-        await window.crypto.subtle.digest('SHA-1', this.#encoder.encode(item))
+        await window.crypto.subtle.digest('SHA-1', this.#encoder.encode(payload))
       ), (byte) => byte.toString(16).padStart(2, '0')).join('')
     );
     this.#data[hash] = item;
@@ -137,7 +139,7 @@ export const initiateLogDownload =
   };
 
 export const storeDownloadedLog =
-  (uavId: Identifier, logId: LogId, log: string) =>
+  (uavId: Identifier, logId: LogId, log: FlightLog) =>
   async (dispatch: AppDispatch) => {
     const value = await logContents.write(log);
     dispatch(setLogDownloadValue(uavId, logId, value));
@@ -156,7 +158,7 @@ export const getLogDownloadState =
 export const retrieveDownloadedLog = (
   uavId: Identifier,
   logId: LogId
-): AppSelector<string | undefined> =>
+): AppSelector<FlightLog | undefined> =>
   createSelector(getLogDownloadState(uavId, logId), (state) => {
     if (state?.status === LogDownloadStatus.SUCCESS) {
       return logContents.read(state.value);

--- a/src/flockwave/queries.ts
+++ b/src/flockwave/queries.ts
@@ -6,8 +6,6 @@
 import type {
   DroneShowConfiguration,
   FirmwareUpdateTarget,
-  FlightLog,
-  FlightLogMetadata,
   License,
   Response_BCNPROPS,
   Response_EXTCFG,
@@ -37,6 +35,12 @@ import memoize from 'memoizee';
 import { errorToString } from '~/error-handling';
 import type { BeaconPropertiesMap } from '~/features/beacons/types';
 import type { OutdoorCoordinateSystemWithOrigin } from '~/features/show/types';
+import {
+  type FlightLog,
+  type FlightLogMetadata,
+  validateFlightLogMetadata,
+  validateFlockwaveFlightLog,
+} from '~/model/flight-logs';
 import type { ItemLike } from '~/utils/collections';
 import type { LonLat } from '~/utils/geography';
 import { toScaledJSONFromLonLat } from '~/utils/geography';
@@ -222,7 +226,7 @@ export async function getFlightLog(
   }
 
   try {
-    return await hub.startAsyncOperationForSingleId<FlightLog>(
+    const log = await hub.startAsyncOperationForSingleId<FlightLog>(
       uavId,
       {
         type: 'LOG-DATA',
@@ -233,6 +237,7 @@ export async function getFlightLog(
       //                  it as string | undefined only
       { idProp: null, onProgress, single: true }
     );
+    return validateFlockwaveFlightLog(log);
   } catch (error) {
     const errorString = errorToString(error);
     throw new Error(
@@ -253,10 +258,10 @@ export async function getFlightLogList(
   }
 
   try {
-    return await hub.startAsyncOperationForSingleId<FlightLogMetadata[]>(
-      uavId,
-      { type: 'LOG-INF' }
-    );
+    const response = await hub.startAsyncOperationForSingleId<
+      FlightLogMetadata[]
+    >(uavId, { type: 'LOG-INF' });
+    return response.map(validateFlightLogMetadata);
   } catch (error) {
     const errorString = errorToString(error);
     throw new Error(

--- a/src/model/flight-logs.ts
+++ b/src/model/flight-logs.ts
@@ -3,15 +3,24 @@ import fromUnixTime from 'date-fns/fromUnixTime';
 import { Base64 } from 'js-base64';
 import isNil from 'lodash-es/isNil';
 
+import type {
+  FlightLog as FlockwaveFlightLog,
+  FlightLogMetadata as FlockwaveFlightLogMetadata,
+} from '@skybrush/flockwave-spec';
+
 import { FlightLogKind } from './enums';
 
 export { FlightLogKind } from './enums';
 
-export type FlightLog = {
-  kind: FlightLogKind;
-  body: string;
-  id?: string;
+export type FlightLogMetadata = {
+  id: string;
   timestamp?: number;
+  kind: FlightLogKind;
+  size?: number;
+};
+
+export type FlightLog = FlightLogMetadata & {
+  body: string;
 };
 
 const _EXTENSIONS_FOR_FLIGHT_LOG_KINDS: Record<FlightLogKind, string> = {
@@ -72,4 +81,35 @@ export function proposeFilenameForFlightLog(flightLog: FlightLog): string {
   } else {
     return `${id}_${ts}${extension}`;
   }
+}
+
+function validateFlightLogKind(value: string): FlightLogKind {
+  return (Object.values(FlightLogKind) as string[]).includes(value)
+    ? (value as FlightLogKind)
+    : FlightLogKind.UNKNOWN;
+}
+
+export function validateFlightLogMetadata(
+  metadata: FlockwaveFlightLogMetadata
+): FlightLogMetadata {
+  return {
+    id: metadata.id,
+    timestamp: metadata.timestamp,
+    kind: validateFlightLogKind(metadata.kind),
+    size: metadata.size,
+  };
+}
+
+export function validateFlockwaveFlightLog(log: FlockwaveFlightLog): FlightLog {
+  const kind = validateFlightLogKind(log.kind);
+  let body = log.body;
+  if (!(typeof body === 'string')) {
+    if (kind === FlightLogKind.UNKNOWN) {
+      body = JSON.stringify(body);
+    } else {
+      throw new Error('log.body must be a string');
+    }
+  }
+
+  return { kind, body, id: log.id, timestamp: log.timestamp, size: log.size };
 }


### PR DESCRIPTION
There are multiple changes here:

- Flight log related typing improvements and extra validation
- Bugfix: only the last downloaded log was stored in Live, and it was downloaded, no matter which log the user requested (root cause: incorrect log type assumption, fixed with `JSON.stringify()` before text encoding)
- `UAVLogsPanel` is now in TS

@ntamas I should note that Live will now keep all downloaded logs in memory. Let me know if this could be a problem, and I'll add an LRU utility.