### PR TITLE
Convert PreflightStatusPanel to TS

### DIFF
--- a/src/components/MiniTable.tsx
+++ b/src/components/MiniTable.tsx
@@ -1,5 +1,5 @@
 import isNil from 'lodash-es/isNil';
-import PropTypes from 'prop-types';
+import type React from 'react';
 
 import { makeStyles } from '@skybrush/app-theme-mui';
 
@@ -22,13 +22,17 @@ const useStyles = makeStyles((theme) => ({
   value: {
     textAlign: 'right',
   },
-
-  separator: {},
 }));
 
 export const naText = <span className='muted'>—</span>;
 
-const MiniTable = ({ items }) => {
+export type MiniTableItem = string | [string, React.ReactNode];
+
+type MiniTableProps = {
+  items: MiniTableItem[];
+};
+
+const MiniTable = ({ items }: MiniTableProps) => {
   const classes = useStyles();
 
   return (
@@ -44,19 +48,13 @@ const MiniTable = ({ items }) => {
             </tr>
           ) : (
             <tr key={row}>
-              <td className={classes.separator} colSpan={2} />
+              <td colSpan={2} />
             </tr>
           )
         )}
       </tbody>
     </table>
   );
-};
-
-MiniTable.propTypes = {
-  items: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.node)])
-  ),
 };
 
 export default MiniTable;

--- a/src/features/uavs/PreflightStatusPanel.tsx
+++ b/src/features/uavs/PreflightStatusPanel.tsx
@@ -4,12 +4,12 @@ import Divider from '@mui/material/Divider';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
-import PropTypes from 'prop-types';
 import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { useAsyncRetry, useUnmount } from 'react-use';
 
+import type { UAVPreflightCheckInfo } from '@skybrush/flockwave-spec';
 import {
   BackgroundHint,
   FormHeader as Header,
@@ -24,13 +24,16 @@ import {
   describeOverallPreflightCheckResult,
   describePreflightCheckResult,
   getSemanticsForPreflightCheckResult,
-  PreflightCheckResult,
 } from '~/model/enums';
-import CustomPropTypes from '~/utils/prop-types';
+import type { RootState } from '~/store/reducers';
 
 import { getUAVById } from './selectors';
 
-const ErrorList = ({ errorCodes }) => {
+type ErrorListProps = {
+  errorCodes?: UAVErrorCode[];
+};
+
+const ErrorList = ({ errorCodes }: ErrorListProps) => {
   const { t } = useTranslation();
   const relevantErrorCodes = (errorCodes || []).filter(
     (code) =>
@@ -56,11 +59,13 @@ const ErrorList = ({ errorCodes }) => {
   );
 };
 
-ErrorList.propTypes = {
-  errorCodes: PropTypes.arrayOf(PropTypes.number),
-};
+type PreflightStatusResultsProps = UAVPreflightCheckInfo;
 
-const PreflightStatusResults = ({ message, result, items }) => {
+const PreflightStatusResults = ({
+  items,
+  message,
+  result,
+}: PreflightStatusResultsProps) => {
   const { t } = useTranslation();
   return (
     <>
@@ -86,7 +91,7 @@ const PreflightStatusResults = ({ message, result, items }) => {
                 <ListItemText
                   primary={
                     message ||
-                    (item.result === PreflightCheckResult.PASS
+                    (item.result === 'pass'
                       ? item.label
                       : `${item.label} — ${describePreflightCheckResult(
                           item.result,
@@ -103,103 +108,111 @@ const PreflightStatusResults = ({ message, result, items }) => {
   );
 };
 
-PreflightStatusResults.propTypes = {
-  items: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string,
-      label: PropTypes.string,
-      message: PropTypes.string,
-      result: CustomPropTypes.preflightCheckResult,
-    })
-  ),
-  message: PropTypes.string,
-  result: CustomPropTypes.preflightCheckResult,
+type PreflightStatusPanelLowerSegmentProps = {
+  uavId?: string;
 };
 
-const PreflightStatusPanelLowerSegment = memo(({ uavId }) => {
-  const messageHub = useMessageHub();
-  const state = useAsyncRetry(
-    () => (uavId ? messageHub.query.getPreflightStatus(uavId) : {}),
-    [messageHub, uavId]
-  );
-  const scheduledRefresh = useRef();
+const missingUAVCheckInfo: UAVPreflightCheckInfo = {
+  items: [],
+  result: 'off',
+};
 
-  // Refresh the status every second
-  useEffect(() => {
-    const isResultReady =
-      uavId && !state.loading && !state.error && Boolean(state.value);
-    if (isResultReady && !scheduledRefresh.current) {
-      scheduledRefresh.current = setTimeout(() => {
-        scheduledRefresh.current = undefined;
-        state.retry();
-      }, 1000);
+const PreflightStatusPanelLowerSegment = memo(
+  ({ uavId }: PreflightStatusPanelLowerSegmentProps) => {
+    const messageHub = useMessageHub();
+    const state = useAsyncRetry(
+      () =>
+        uavId
+          ? messageHub.query.getPreflightStatus(uavId)
+          : Promise.resolve(missingUAVCheckInfo),
+      [messageHub, uavId]
+    );
+    const scheduledRefresh = useRef<ReturnType<typeof setTimeout>>();
+
+    // Refresh the status every second
+    useEffect(() => {
+      const isResultReady =
+        uavId && !state.loading && !state.error && Boolean(state.value);
+      if (isResultReady && !scheduledRefresh.current) {
+        scheduledRefresh.current = setTimeout(() => {
+          scheduledRefresh.current = undefined;
+          state.retry();
+        }, 1000);
+      }
+    }, [state, uavId]);
+
+    // Cancel scheduled refreshes when unmounting
+    useUnmount(() => {
+      if (scheduledRefresh.current) {
+        clearTimeout(scheduledRefresh.current);
+      }
+    });
+
+    if (state.error && !state.loading) {
+      return (
+        <BackgroundHint
+          icon={<Error />}
+          text='Error while loading preflight status report'
+          button={<Button onClick={state.retry}>Try again</Button>}
+        />
+      );
     }
-  }, [state, uavId]);
 
-  // Cancel scheduled refreshes when unmounting
-  useUnmount(() => {
-    if (scheduledRefresh.current) {
-      clearTimeout(scheduledRefresh.current);
+    if (state.value) {
+      return (
+        <PreflightStatusResults
+          message={state.value.message}
+          result={state.value.result}
+          items={state.value.items}
+        />
+      );
     }
-  });
 
-  if (state.error && !state.loading) {
+    if (state.loading) {
+      return (
+        <LargeProgressIndicator
+          fullHeight
+          label='Retrieving status report...'
+        />
+      );
+    }
+
     return (
       <BackgroundHint
-        icon={<Error />}
-        text='Error while loading preflight status report'
+        text='Preflight status report not loaded yet'
         button={<Button onClick={state.retry}>Try again</Button>}
       />
     );
   }
+);
 
-  if (state.value) {
-    return (
-      <PreflightStatusResults
-        message={state.value.message}
-        result={state.value.result}
-        items={state.value.items}
-      />
-    );
-  }
+PreflightStatusPanelLowerSegment.displayName =
+  'PreflightStatusPanelLowerSegment';
 
-  if (state.loading) {
-    return (
-      <LargeProgressIndicator fullHeight label='Retrieving status report...' />
-    );
-  }
-
-  return (
-    <BackgroundHint
-      text='Preflight status report not loaded yet'
-      button={<Button onClick={state.retry}>Try again</Button>}
-    />
-  );
-});
-
-PreflightStatusPanelLowerSegment.propTypes = {
-  uavId: PropTypes.string,
+type PreflightStatusPanelOwnProps = {
+  uavId?: string;
 };
+type PreflightStatusPanelDiospatchProps = {
+  errorCodes?: UAVErrorCode[];
+};
+type PreflightStatusPanelProps = PreflightStatusPanelOwnProps &
+  PreflightStatusPanelDiospatchProps;
 
-const PreflightStatusPanel = ({ errorCodes, uavId }) => (
+const PreflightStatusPanel = ({
+  errorCodes,
+  uavId,
+}: PreflightStatusPanelProps) => (
   <>
     <ErrorList errorCodes={errorCodes} />
     <PreflightStatusPanelLowerSegment uavId={uavId} />
   </>
 );
 
-PreflightStatusPanel.propTypes = {
-  errorCodes: PropTypes.arrayOf(PropTypes.number),
-  uavId: PropTypes.string,
-};
-
 export default connect(
   // mapStateToProps
-  (state, ownProps) => ({
+  (state: RootState, ownProps: PreflightStatusPanelOwnProps) => ({
     errorCodes: ownProps.uavId
       ? getUAVById(state, ownProps.uavId)?.errors
-      : null,
-  }),
-  // mapDispatchToProps
-  {}
+      : undefined,
+  })
 )(PreflightStatusPanel);

--- a/src/features/uavs/StatusSummaryMiniTable.js
+++ b/src/features/uavs/StatusSummaryMiniTable.js
@@ -162,8 +162,5 @@ StatusSummaryMiniTable.propTypes = {
 
 export default connect(
   // mapStateToProps
-  (state, ownProps) => getUAVById(state, ownProps.uavId),
-
-  // mapDispatchToProps
-  {}
+  (state, ownProps) => getUAVById(state, ownProps.uavId) ?? {}
 )(StatusSummaryMiniTable);

--- a/src/features/uavs/UAVDetailsDialogBody.tsx
+++ b/src/features/uavs/UAVDetailsDialogBody.tsx
@@ -1,29 +1,37 @@
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import MessagesPanel from '~/components/chat/MessagesPanel';
+import type { RootState } from '~/store/reducers';
 
 import PreflightStatusPanel from './PreflightStatusPanel';
 import UAVLogsPanel from './UAVLogsPanel';
 import UAVTestsPanel from './UAVTestsPanel';
-
 import {
   getSelectedTabInUAVDetailsDialog,
   getSelectedUAVIdInUAVDetailsDialog,
 } from './details';
+import { UAVDetailsDialogTab } from './types';
 
-const UAVDetailsDialogBody = ({ selectedTab, uavId }) => {
+type UAVDetailsDialogBodyProps = {
+  selectedTab: UAVDetailsDialogTab;
+  uavId?: string;
+};
+
+const UAVDetailsDialogBody = ({
+  selectedTab,
+  uavId,
+}: UAVDetailsDialogBodyProps) => {
   switch (selectedTab) {
-    case 'messages':
+    case UAVDetailsDialogTab.MESSAGES:
       return <MessagesPanel uavId={uavId} />;
 
-    case 'preflight':
+    case UAVDetailsDialogTab.PREFLIGHT:
       return <PreflightStatusPanel uavId={uavId} />;
 
-    case 'tests':
+    case UAVDetailsDialogTab.TESTS:
       return <UAVTestsPanel uavId={uavId} />;
 
-    case 'logs':
+    case UAVDetailsDialogTab.LOGS:
       return <UAVLogsPanel uavId={uavId} />;
 
     default:
@@ -31,14 +39,9 @@ const UAVDetailsDialogBody = ({ selectedTab, uavId }) => {
   }
 };
 
-UAVDetailsDialogBody.propTypes = {
-  selectedTab: PropTypes.oneOf(['messages', 'preflight', 'tests', 'logs']),
-  uavId: PropTypes.string,
-};
-
 export default connect(
   // mapStateToProps
-  (state) => ({
+  (state: RootState) => ({
     selectedTab: getSelectedTabInUAVDetailsDialog(state),
     uavId: getSelectedUAVIdInUAVDetailsDialog(state),
   })

--- a/src/features/uavs/UAVTestsPanel.tsx
+++ b/src/features/uavs/UAVTestsPanel.tsx
@@ -85,7 +85,7 @@ type UAVTestButtonProps = {
   needsConfirmation?: boolean;
   timeout?: number;
   type: UAVTestType;
-  uavId: string;
+  uavId?: string;
 };
 
 const UAVTestButton = ({
@@ -146,6 +146,9 @@ const UAVTestButton = ({
 
   const [lastExecutionState, execute] = useAsyncFn(async () => {
     lastExecutedUavIdRef.current = uavId;
+    if (uavId === undefined) {
+      return;
+    }
     // TODO(ntamas): use the proper UAV-TEST messages designated for this
     await messageHub.sendCommandRequest(
       {
@@ -242,7 +245,7 @@ const UAVTestButton = ({
 };
 
 type UAVTestsPanelProps = {
-  uavId: string;
+  uavId?: string;
 };
 
 const UAVTestsPanel = ({ uavId }: UAVTestsPanelProps) => {

--- a/src/model/enums.ts
+++ b/src/model/enums.ts
@@ -1,3 +1,5 @@
+import type { PreflightCheckResult as FlockwavePreflightCheckResult } from '@skybrush/flockwave-spec';
+
 import { Status } from '~/components/semantics';
 import type { TranslateFn } from '~/i18n/types';
 
@@ -283,7 +285,7 @@ export function getSemanticsForFlightMode(
   mode: FlightMode
 ): Status | undefined {
   const props =
-    propertiesForFlightModes[mode] ||
+    propertiesForFlightModes[mode] ??
     propertiesForFlightModes[FlightMode.UNKNOWN];
   return props.status;
 }
@@ -374,7 +376,7 @@ const propertiesForGPSFixTypes: Record<
  */
 export function abbreviateGPSFixType(fixType: GPSFixType): string {
   const props =
-    propertiesForGPSFixTypes[fixType] ||
+    propertiesForGPSFixTypes[fixType] ??
     propertiesForGPSFixTypes[GPSFixType.UNKNOWN];
   return props.abbreviation;
 }
@@ -398,7 +400,7 @@ export function describeGPSFixType(
  */
 export function getSemanticsForGPSFixType(fixType: GPSFixType): Status {
   const props =
-    propertiesForGPSFixTypes[fixType] ||
+    propertiesForGPSFixTypes[fixType] ??
     propertiesForGPSFixTypes[GPSFixType.UNKNOWN];
   return props.status;
 }
@@ -423,19 +425,7 @@ export function getSemanticsForRSSI(rssi?: number): Status {
 
 /* ************************************************************************* */
 
-/**
- * Enum representing the possible preflight check results on a UAV.
- */
-export enum PreflightCheckResult {
-  OFF = 'off',
-  PASS = 'pass',
-  WARNING = 'warning',
-  RUNNING = 'running',
-  SOFT_FAILURE = 'softFailure',
-  FAILURE = 'failure',
-  ERROR = 'error',
-  UNKNOWN = 'unknown',
-}
+export type PreflightCheckResult = FlockwavePreflightCheckResult | 'unknown';
 
 /**
  * Object mapping preflight check result constants to their properties (human
@@ -451,42 +441,42 @@ const propertiesForPreflightCheckResults: Record<
     status: Status;
   }
 > = {
-  [PreflightCheckResult.OFF]: {
+  off: {
     description: 'Disabled',
     overallDescription: 'All preflight checks are disabled',
     status: Status.OFF,
   },
-  [PreflightCheckResult.PASS]: {
+  pass: {
     description: 'OK',
     overallDescription: 'Preflight checks passed',
     status: Status.SUCCESS,
   },
-  [PreflightCheckResult.WARNING]: {
+  warning: {
     description: 'Needs attention',
     overallDescription: 'Some preflight check items need attention',
     status: Status.WARNING,
   },
-  [PreflightCheckResult.RUNNING]: {
+  running: {
     description: 'Check in progress...',
     overallDescription: 'Preflight checks are in progress...',
     status: Status.WAITING,
   },
-  [PreflightCheckResult.SOFT_FAILURE]: {
+  softFailure: {
     description: 'Temporary failure',
     overallDescription: 'Some preflight checks failed temporarily',
     status: Status.WARNING,
   },
-  [PreflightCheckResult.FAILURE]: {
+  failure: {
     description: 'Failed',
     overallDescription: 'Preflight checks failed',
     status: Status.ERROR,
   },
-  [PreflightCheckResult.ERROR]: {
+  error: {
     description: 'Error while executing test',
     overallDescription: 'Error while executing preflight checks',
     status: Status.CRITICAL,
   },
-  [PreflightCheckResult.UNKNOWN]: {
+  unknown: {
     description: 'Unknown test result',
     overallDescription: 'Unknown preflight test result',
     status: Status.OFF,
@@ -502,7 +492,7 @@ export function describePreflightCheckResult(
 ): string {
   const resolvedResult = propertiesForPreflightCheckResults[result]
     ? result
-    : PreflightCheckResult.UNKNOWN;
+    : 'unknown';
   const description =
     propertiesForPreflightCheckResults[resolvedResult].description;
   return t
@@ -519,7 +509,7 @@ export function describeOverallPreflightCheckResult(
 ): string {
   const resolvedResult = propertiesForPreflightCheckResults[result]
     ? result
-    : PreflightCheckResult.UNKNOWN;
+    : 'unknown';
   const description =
     propertiesForPreflightCheckResults[resolvedResult].overallDescription;
   return t
@@ -534,7 +524,7 @@ export function getSemanticsForPreflightCheckResult(
   result: PreflightCheckResult
 ): Status {
   const props =
-    propertiesForPreflightCheckResults[result] ||
-    propertiesForPreflightCheckResults[PreflightCheckResult.UNKNOWN];
+    propertiesForPreflightCheckResults[result] ??
+    propertiesForPreflightCheckResults['unknown'];
   return props.status;
 }

--- a/src/utils/prop-types.ts
+++ b/src/utils/prop-types.ts
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types';
 
-import { PreflightCheckResult, Severity } from '~/model/enums';
-
 const CustomPropTypes = {
   angle: PropTypes.number,
 
@@ -9,10 +7,6 @@ const CustomPropTypes = {
     lat: PropTypes.number.isRequired,
     lon: PropTypes.number.isRequired,
   }),
-
-  preflightCheckResult: PropTypes.oneOf(Object.values(PreflightCheckResult)),
-
-  severity: PropTypes.oneOf(Object.values(Severity)),
 };
 
 export default CustomPropTypes;


### PR DESCRIPTION
I removed the `PreflightCheckResult` enum to avoid conversions from the flockwave message. The types match, except Live adds an extra `unknown` option, which I didn't want to remove. Let me know if you'd prefer removing the `unknown` option or restoring the enum and converting in the `getPreflightStatus()` query.