### PR TITLE
Fix: cancel all pending operations when the server disconnects

### DIFF
--- a/src/components/ServerConnectionManager.jsx
+++ b/src/components/ServerConnectionManager.jsx
@@ -55,6 +55,7 @@ import { showError, showNotification } from '~/features/snackbar/actions';
 import { MessageSemantics } from '~/features/snackbar/types';
 import { clearTasks } from '~/features/tasks/slice';
 import { clearWeatherData } from '~/features/weather/slice';
+import { ConnectionLostError } from '~/flockwave/messages';
 import i18n from '~/i18n';
 import messageHub from '~/message-hub';
 import {
@@ -669,6 +670,13 @@ const createCommonDisconnectionAndErrorHandlerThunk =
     const { url, reason, wasConnected, willReconnect } = event;
 
     dispatch(setCurrentServerConnectionState(ConnectionState.DISCONNECTED));
+
+    // With the server gone, in-flight operations can no longer complete.
+    // We must reject all pending operations, so promises don't need to
+    // wait until the timeout is reached.
+    messageHub.cancelAllPendingOperationsAndResponses(
+      new ConnectionLostError()
+    );
 
     switch (reason) {
       case 'connection error':

--- a/src/flockwave/messages.ts
+++ b/src/flockwave/messages.ts
@@ -108,6 +108,16 @@ export class EmitterChangedError extends Error {
 }
 
 /**
+ * Error class thrown by promises when the connection to the server is lost
+ * while waiting for a response from the server.
+ */
+export class ConnectionLostError extends Error {
+  constructor(message?: string) {
+    super(message ?? 'Connection to the server was lost');
+  }
+}
+
+/**
  * Error class thrown when the user attempts to send a message without an
  * emitter being associated to the hub.
  */
@@ -1248,9 +1258,7 @@ export default class MessageHub {
       return;
     }
 
-    const error = new EmitterChangedError();
-    this._asyncOperationManager.cancelAll(error);
-    this.cancelAllPendingResponses();
+    this.cancelAllPendingOperationsAndResponses(new EmitterChangedError());
 
     this._emitter = value;
 
@@ -1277,12 +1285,16 @@ export default class MessageHub {
   }
 
   /**
-   * Cancels all pending responses by rejecting the corresponding promises
-   * with an error.
+   * Cancels all pending operations and responses by rejecting the
+   * corresponding promises with the given error.
+   *
+   * @param error  the error to reject the promises with
    */
-  cancelAllPendingResponses(): void {
+  cancelAllPendingOperationsAndResponses(error: Error): void {
+    this._asyncOperationManager.cancelAll(error);
+
     for (const pendingResponse of Object.values(this._pendingResponses)) {
-      pendingResponse.reject(new EmitterChangedError());
+      pendingResponse.reject(error);
     }
 
     this._pendingResponses = {};


### PR DESCRIPTION
@vasarhelyi Note that this doesn't fully solve the connection loss and stuck loading state problem you mentioned.

If Live tries to upload a large file to the server, the server may not be able to send a ping in time, and the connection will be broken (and reestablished immediately after). We'll discuss a solution to this.

What this PR fixes is that all pending promises (in-flight server operations) will be rejected when connection is broken, meaning the CRTH dialog won't need to wait until the operation's timeout to get back to a working state.