### PR TITLE
feat: translate names of reported firmware components + remove i18nex…

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -15,18 +15,7 @@
     "@babel/preset-react",
     "@babel/preset-typescript"
   ],
-  "plugins": [
-    ["@babel/plugin-proposal-decorators", { "legacy": true }],
-    [
-      "i18next-extract",
-      {
-        "discardOldKeys": false,
-        "locales": ["en"],
-        "tFunctionNames": ["tt"],
-        "outputPath": "src/i18n/{{locale}}.json"
-      }
-    ]
-  ],
+  "plugins": [["@babel/plugin-proposal-decorators", { "legacy": true }]],
   "env": {
     "test": {
       "plugins": ["@babel/plugin-transform-modules-commonjs"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,7 +189,6 @@
         "@types/which": "^3.0.4",
         "babel-jest": "^30.2.0",
         "babel-loader": "^10.1.1",
-        "babel-plugin-i18next-extract": "^1.1.0",
         "cross-env": "^10.1.0",
         "css-loader": "^7.1.4",
         "dotenv-webpack": "^9.0.0",
@@ -7479,69 +7478,6 @@
           "optional": true
         },
         "webpack": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/babel-plugin-i18next-extract": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-i18next-extract/-/babel-plugin-i18next-extract-1.1.0.tgz",
-      "integrity": "sha512-PakTFKErA1FWlRcUGdJhI6fYKkKHY3QfOAu72bVS+y5ie27TaRu9yECtRk9ZVdKozf75LfkuirfidmPlTxxRSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/types": "7.28.0",
-        "deepmerge": "^4.3.1",
-        "i18next": "^25.3.1",
-        "json-stable-stringify": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/babel-plugin-i18next-extract/node_modules/@babel/types": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.0.tgz",
-      "integrity": "sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/babel-plugin-i18next-extract/node_modules/i18next": {
-      "version": "25.10.10",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
-      "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://www.locize.com/i18next"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.locize.com"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.29.2"
-      },
-      "peerDependencies": {
-        "typescript": "^5 || ^6"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -207,7 +207,6 @@
     "@types/which": "^3.0.4",
     "babel-jest": "^30.2.0",
     "babel-loader": "^10.1.1",
-    "babel-plugin-i18next-extract": "^1.1.0",
     "cross-env": "^10.1.0",
     "css-loader": "^7.1.4",
     "dotenv-webpack": "^9.0.0",

--- a/src/features/upload-support/value-consistency/ValueConsistencyResultPanel.tsx
+++ b/src/features/upload-support/value-consistency/ValueConsistencyResultPanel.tsx
@@ -19,7 +19,7 @@ import {
   StatusPill,
 } from '@skybrush/mui-components';
 
-import type { PreparedI18nKey } from '~/i18n';
+import type { PreparedI18nKey, PreparedI18nRecord } from '~/i18n';
 import type { RootState } from '~/store/reducers';
 import type { Identifier } from '~/utils/collections';
 import { formatIdsAndTruncateTrailingItems } from '~/utils/formatting';
@@ -36,6 +36,11 @@ type ValueConsistencyMessages = Readonly<{
   errors: PreparedI18nKey;
   inconsistencies: PreparedI18nKey;
 }>;
+
+/**
+ * Maybe partial translation record for names shown in the per-name breakdown.
+ */
+type TranslatedNames = Readonly<Record<string, string>>;
 
 // -- Value grid row
 
@@ -124,7 +129,7 @@ const ValueGrid = ({ valueMap, majorityValue }: ValueGridProps) => {
 // -- Named-value accordion
 
 type ValueAccordionProps = Readonly<{
-  name: string;
+  label: string;
   valueMap: Record<string, Identifier[]>;
   majorityValue: string | undefined;
 }>;
@@ -152,11 +157,11 @@ const useValueAccordionStyles = makeStyles((theme) => ({
 }));
 
 /**
- * Renders a single name as an expandable accordion with a per-value
- * breakdown in its details.
+ * Renders a single (maybe raw, maybe translated) as an expandable accordion
+ * with a per-value breakdown in its details.
  */
 const ValueAccordion = ({
-  name,
+  label,
   valueMap,
   majorityValue,
 }: ValueAccordionProps) => {
@@ -173,7 +178,7 @@ const ValueAccordion = ({
     <Accordion disableGutters>
       <AccordionSummary expandIcon={<ExpandMoreIcon />}>
         <Stack className={classes.accordionSummaryStack}>
-          <Typography component='span'>{name}</Typography>
+          <Typography component='span'>{label}</Typography>
           <Box className={classes.spacer} />
           <Stack className={classes.statusStack}>
             <LabeledStatusLight status={Status.SUCCESS} size='small'>
@@ -240,11 +245,13 @@ const useValueConsistencyResultPanelStyles = makeStyles((theme) => ({
 type ValueConsistencyResultPanelProps = Readonly<{
   jobType: string;
   messages: ValueConsistencyMessages;
+  names?: PreparedI18nRecord;
 }>;
 
 const ValueConsistencyResultPanel = ({
   jobType,
   messages,
+  names,
 }: ValueConsistencyResultPanelProps) => {
   const { t } = useTranslation();
   const classes = useValueConsistencyResultPanelStyles();
@@ -264,7 +271,15 @@ const ValueConsistencyResultPanel = ({
     );
   }
 
-  const sortedNames = Object.keys(distribution).sort();
+  const translatedNames: TranslatedNames | undefined = names?.(t);
+  const rows = Object.entries(distribution)
+    .map(([name, valueMap]) => ({
+      name,
+      label: translatedNames?.[name] ?? name,
+      valueMap,
+      majorityValue: majority[name],
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
 
   return (
     <Box className={classes.root}>
@@ -273,12 +288,12 @@ const ValueConsistencyResultPanel = ({
         inconsistencyCount={inconsistencyCount}
         messages={messages}
       />
-      {sortedNames.map((name) => (
+      {rows.map(({ name, label, valueMap, majorityValue }) => (
         <ValueAccordion
           key={name}
-          name={name}
-          valueMap={distribution[name]}
-          majorityValue={majority[name]}
+          label={label}
+          valueMap={valueMap}
+          majorityValue={majorityValue}
         />
       ))}
     </Box>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -313,6 +313,15 @@
     }
   },
   "firmwareCheck": {
+    "names": {
+      "board": "Board revision",
+      "firmware": "Firmware version",
+      "flight_sw": "Flight software version",
+      "middleware_sw": "Middleware version",
+      "os_sw": "Operating system version",
+      "revision": "Revision",
+      "server": "Server version"
+    },
     "result": {
       "consistent": "All firmware versions consistent.",
       "errors": "Error while checking firmware versions. Check the results below.",

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -72,3 +72,25 @@ export const tt =
   (key: string, options?: TOptions): PreparedI18nKey =>
   (t: TFunction) =>
     options ? t(key, options) : t(key);
+
+/**
+ * Prepared lookup of an i18n namespace, resolving to a plain record
+ * with string keys.
+ */
+export type PreparedI18nRecord = (
+  t: TFunction
+) => Readonly<Record<string, string>>;
+
+/**
+ * Same as tt, but for an entire i18n namespace.
+ */
+export const ttRecord =
+  (key: string): PreparedI18nRecord =>
+  (t) => {
+    // Falls back to an empty record when the key does not resolve to an
+    // object; with `returnObjects`, i18next yields the key itself instead.
+    const result: unknown = t(key, { returnObjects: true });
+    return typeof result === 'object' && result !== null
+      ? (result as Record<string, string>)
+      : {};
+  };

--- a/src/upload-jobs.js
+++ b/src/upload-jobs.js
@@ -9,7 +9,7 @@ import showUploadJobSpecification from '~/features/show/upload';
 import { registerUploadJobType } from '~/features/upload/jobs';
 import { registerUploadJobResultPanel } from '~/features/upload/result-panels';
 import ValueConsistencyResultPanel from '~/features/upload-support/value-consistency/ValueConsistencyResultPanel';
-import { tt } from '~/i18n';
+import { tt, ttRecord } from '~/i18n';
 
 function registerUploadJobTypes() {
   const specs = [
@@ -44,6 +44,7 @@ function registerUploadJobTypes() {
           errors: tt('firmwareCheck.result.errors'),
           inconsistencies: tt('firmwareCheck.result.inconsistencies'),
         },
+        names: ttRecord('firmwareCheck.names'),
       }
     )
   );


### PR DESCRIPTION
…t-extract plugin (hate it)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized names for firmware check items, including board revision, firmware version, flight software, middleware, operating system, revision, and server version.
  * Firmware check results now display translated labels when available, with automatic fallback to the original names.
  * Results are sorted by their displayed labels for easier navigation.

* **Bug Fixes**
  * Improved handling of missing or unavailable translations in firmware check result panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->